### PR TITLE
feat(memory): implement 3-tier memory hierarchy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,5 +11,5 @@ repos:
     rev: v0.1.0
     hooks:
       - id: ruff
-        args: [--fix]
+        # args: [--fix]  # removed --fix: causes CI to fail when auto-fixed
       - id: ruff-format

--- a/src/riks_context_engine/memory/__init__.py
+++ b/src/riks_context_engine/memory/__init__.py
@@ -5,6 +5,7 @@ from .embedding import OllamaEmbedder, OllamaEmbeddingError, get_embedder, set_e
 from .episodic import EpisodicEntry, EpisodicMemory
 from .procedural import ProceduralMemory, Procedure
 from .semantic import SemanticEntry, SemanticMemory
+from .tier_manager import TierConfig, TierManager
 
 __all__ = [
     # Base
@@ -24,4 +25,7 @@ __all__ = [
     # Procedural
     "Procedure",
     "ProceduralMemory",
+    # TierManager
+    "TierConfig",
+    "TierManager",
 ]

--- a/src/riks_context_engine/memory/__init__.py
+++ b/src/riks_context_engine/memory/__init__.py
@@ -1,7 +1,27 @@
 """3-tier memory system: Episodic, Semantic, Procedural."""
 
-from .episodic import EpisodicMemory
-from .procedural import ProceduralMemory
-from .semantic import SemanticMemory
+from .base import MemoryEntry, MemoryType
+from .embedding import OllamaEmbedder, OllamaEmbeddingError, get_embedder, set_embedder
+from .episodic import EpisodicEntry, EpisodicMemory
+from .procedural import ProceduralMemory, Procedure
+from .semantic import SemanticEntry, SemanticMemory
 
-__all__ = ["EpisodicMemory", "SemanticMemory", "ProceduralMemory"]
+__all__ = [
+    # Base
+    "MemoryEntry",
+    "MemoryType",
+    # Embedding
+    "OllamaEmbedder",
+    "OllamaEmbeddingError",
+    "get_embedder",
+    "set_embedder",
+    # Episodic
+    "EpisodicEntry",
+    "EpisodicMemory",
+    # Semantic
+    "SemanticEntry",
+    "SemanticMemory",
+    # Procedural
+    "Procedure",
+    "ProceduralMemory",
+]

--- a/src/riks_context_engine/memory/base.py
+++ b/src/riks_context_engine/memory/base.py
@@ -53,6 +53,10 @@ class MemoryEntry:
     last_accessed: datetime | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        self.importance = max(0.0, min(1.0, float(self.importance)))
+        self.access_count = max(0, int(self.access_count))
+
     def record_access(self) -> None:
         """Increment access counter and update last_accessed."""
         self.access_count += 1
@@ -68,9 +72,7 @@ class MemoryEntry:
             "importance": self.importance,
             "embedding": self.embedding,
             "access_count": self.access_count,
-            "last_accessed": (
-                self.last_accessed.isoformat() if self.last_accessed else None
-            ),
+            "last_accessed": (self.last_accessed.isoformat() if self.last_accessed else None),
             "metadata": self.metadata,
         }
 

--- a/src/riks_context_engine/memory/base.py
+++ b/src/riks_context_engine/memory/base.py
@@ -1,0 +1,96 @@
+"""Shared MemoryEntry schema for the 3-tier memory system."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+
+class MemoryType(Enum):
+    """Discriminator for the three memory tiers."""
+
+    EPISODIC = "episodic"
+    SEMANTIC = "semantic"
+    PROCEDURAL = "procedural"
+
+
+@dataclass
+class MemoryEntry:
+    """Unified schema for all memory entries.
+
+    Attributes
+    ----------
+    id : str
+        Unique identifier prefixed by tier (e.g. ``ep_123``).
+    type : MemoryType
+        Which tier this entry belongs to.
+    content : str
+        Human-readable content (the "fact" or "observation").
+    timestamp : datetime
+        When this entry was created (UTC).
+    importance : float
+        Significance score in [0.0, 1.0]. Higher values are kept longer.
+    embedding : list[float] | None
+        Vector representation for semantic search. Generated on-demand
+        for episodic/procedural; stored for semantic.
+    access_count : int
+        Number of times this entry has been retrieved.
+    last_accessed : datetime | None
+        UTC timestamp of most recent retrieval.
+    metadata : dict[str, Any]
+        Tier-specific extra fields.
+    """
+
+    id: str
+    type: MemoryType
+    content: str
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    importance: float = 0.5
+    embedding: list[float] | None = None
+    access_count: int = 0
+    last_accessed: datetime | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def record_access(self) -> None:
+        """Increment access counter and update last_accessed."""
+        self.access_count += 1
+        self.last_accessed = datetime.now(timezone.utc)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "id": self.id,
+            "type": self.type.value,
+            "content": self.content,
+            "timestamp": self.timestamp.isoformat(),
+            "importance": self.importance,
+            "embedding": self.embedding,
+            "access_count": self.access_count,
+            "last_accessed": (
+                self.last_accessed.isoformat() if self.last_accessed else None
+            ),
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MemoryEntry:
+        """Reconstruct a MemoryEntry from a dictionary."""
+        timestamp = data["timestamp"]
+        if isinstance(timestamp, str):
+            timestamp = datetime.fromisoformat(timestamp)
+        last_accessed = data.get("last_accessed")
+        if isinstance(last_accessed, str):
+            last_accessed = datetime.fromisoformat(last_accessed)
+        return cls(
+            id=data["id"],
+            type=MemoryType(data["type"]),
+            content=data["content"],
+            timestamp=timestamp,
+            importance=data.get("importance", 0.5),
+            embedding=data.get("embedding"),
+            access_count=data.get("access_count", 0),
+            last_accessed=last_accessed,
+            metadata=data.get("metadata", {}),
+        )

--- a/src/riks_context_engine/memory/embedding.py
+++ b/src/riks_context_engine/memory/embedding.py
@@ -34,9 +34,7 @@ class OllamaEmbedder:
         model: str = "nomic-embed-text",
         timeout: float = 30.0,
     ):
-        self.base_url = base_url or os.environ.get(
-            "OLLAMA_BASE_URL", "http://localhost:11434"
-        )
+        self.base_url = base_url or os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
         self.model = model
         self.timeout = timeout
         self._client: httpx.Client | None = None

--- a/src/riks_context_engine/memory/embedding.py
+++ b/src/riks_context_engine/memory/embedding.py
@@ -1,0 +1,144 @@
+"""Ollama embedding service for vector representations."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import httpx
+
+
+@dataclass
+class EmbeddingResult:
+    """Result of an embedding operation."""
+
+    embedding: list[float]
+    model: str
+    prompt_tokens: int | None = None
+
+
+class OllamaEmbeddingError(Exception):
+    """Raised when embedding generation fails."""
+
+
+class OllamaEmbedder:
+    """Generates vector embeddings via Ollama API.
+
+    Uses the nomic-embed-text model by default for
+    high-quality semantic representations.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        model: str = "nomic-embed-text",
+        timeout: float = 30.0,
+    ):
+        self.base_url = base_url or os.environ.get(
+            "OLLAMA_BASE_URL", "http://localhost:11434"
+        )
+        self.model = model
+        self.timeout = timeout
+        self._client: httpx.Client | None = None
+
+    @property
+    def client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(base_url=self.base_url, timeout=self.timeout)
+        return self._client
+
+    def embed(self, text: str) -> EmbeddingResult:
+        """Generate embedding for a single text string."""
+        try:
+            response = self.client.post(
+                "/api/embed",
+                json={"model": self.model, "input": text},
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            # Ollama /api/embed returns {"embeddings": [[...]], "model": "...", "prompt_eval_count": N}
+            embeddings: list[list[float]] = data.get("embeddings", [])
+            if not embeddings:
+                raise OllamaEmbeddingError("No embeddings returned from Ollama")
+
+            return EmbeddingResult(
+                embedding=embeddings[0],
+                model=self.model,
+                prompt_tokens=data.get("prompt_eval_count"),
+            )
+        except httpx.ConnectError as exc:
+            msg = f"Cannot connect to Ollama at {self.base_url}. Is Ollama running?"
+            raise OllamaEmbeddingError(msg) from exc
+        except httpx.HTTPStatusError as exc:
+            msg = f"Ollama API error: {exc.response.status_code} {exc.response.text}"
+            raise OllamaEmbeddingError(msg) from exc
+        except (KeyError, ValueError) as exc:
+            msg = f"Unexpected Ollama response format: {exc}"
+            raise OllamaEmbeddingError(msg) from exc
+
+    def embed_batch(self, texts: list[str]) -> list[EmbeddingResult]:
+        """Generate embeddings for multiple texts in one API call."""
+        try:
+            response = self.client.post(
+                "/api/embed",
+                json={"model": self.model, "input": texts},
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            embeddings: list[list[float]] = data.get("embeddings", [])
+            if len(embeddings) != len(texts):
+                msg = f"Expected {len(texts)} embeddings, got {len(embeddings)}"
+                raise OllamaEmbeddingError(msg)
+
+            prompt_tokens = data.get("prompt_eval_count")
+            return [
+                EmbeddingResult(
+                    embedding=emb,
+                    model=self.model,
+                    prompt_tokens=prompt_tokens,
+                )
+                for emb in embeddings
+            ]
+        except httpx.ConnectError as exc:
+            msg = f"Cannot connect to Ollama at {self.base_url}. Is Ollama running?"
+            raise OllamaEmbeddingError(msg) from exc
+        except httpx.HTTPStatusError as exc:
+            msg = f"Ollama API error: {exc.response.status_code} {exc.response.text}"
+            raise OllamaEmbeddingError(msg) from exc
+        except (KeyError, ValueError) as exc:
+            msg = f"Unexpected Ollama response format: {exc}"
+            raise OllamaEmbeddingError(msg) from exc
+
+    def is_available(self) -> bool:
+        """Check whether the Ollama service is reachable."""
+        try:
+            response = self.client.get("/api/tags", timeout=5.0)
+            return response.status_code == 200
+        except Exception:
+            return False
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+
+# Module-level singleton for convenience
+_default_embedder: OllamaEmbedder | None = None
+
+
+def get_embedder() -> OllamaEmbedder:
+    """Return the default module-level embedder instance."""
+    global _default_embedder
+    if _default_embedder is None:
+        _default_embedder = OllamaEmbedder()
+    return _default_embedder
+
+
+def set_embedder(embedder: OllamaEmbedder) -> None:
+    """Replace the default module-level embedder."""
+    global _default_embedder
+    _default_embedder = embedder

--- a/src/riks_context_engine/memory/episodic.py
+++ b/src/riks_context_engine/memory/episodic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -23,6 +24,10 @@ class EpisodicEntry:
     tags: list[str] | None = None
     access_count: int = 0
     last_accessed: datetime | None = None
+
+    def __post_init__(self) -> None:
+        self.importance = max(0.0, min(1.0, float(self.importance)))
+        self.access_count = max(0, int(self.access_count))
 
     def record_access(self) -> None:
         self.access_count += 1
@@ -63,9 +68,7 @@ class EpisodicEntry:
             "embedding": self.embedding,
             "tags": self.tags,
             "access_count": self.access_count,
-            "last_accessed": (
-                self.last_accessed.isoformat() if self.last_accessed else None
-            ),
+            "last_accessed": (self.last_accessed.isoformat() if self.last_accessed else None),
         }
 
     @classmethod
@@ -112,9 +115,7 @@ class EpisodicMemory:
             try:
                 with open(path, encoding="utf-8") as fh:
                     data = json.load(fh)
-                self._entries = {
-                    d["id"]: EpisodicEntry.from_dict(d) for d in data
-                }
+                self._entries = {d["id"]: EpisodicEntry.from_dict(d) for d in data}
             except (json.JSONDecodeError, KeyError, ValueError):
                 # Corrupt file – start fresh
                 self._entries = {}
@@ -124,8 +125,12 @@ class EpisodicMemory:
         path = Path(self.storage_path)
         path.parent.mkdir(parents=True, exist_ok=True)
         data = [entry.to_dict() for entry in self._entries.values()]
-        with open(path, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, indent=2, ensure_ascii=False)
+        json_bytes = json.dumps(data, indent=2, ensure_ascii=False).encode("utf-8")
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, json_bytes)
+        finally:
+            os.close(fd)
 
     def _generate_id(self) -> str:
         return f"ep_{uuid.uuid4().hex}"
@@ -241,9 +246,7 @@ class EpisodicMemory:
             return 0
 
         # Sort by (importance asc, timestamp asc) – drop lowest importance first
-        sorted_entries = sorted(
-            self._entries.values(), key=lambda e: (e.importance, e.timestamp)
-        )
+        sorted_entries = sorted(self._entries.values(), key=lambda e: (e.importance, e.timestamp))
         to_remove = len(self._entries) - max_entries
         removed = 0
         for entry in sorted_entries:

--- a/src/riks_context_engine/memory/episodic.py
+++ b/src/riks_context_engine/memory/episodic.py
@@ -1,48 +1,281 @@
 """Episodic memory - session-level, short-term observations."""
 
+from __future__ import annotations
+
+import json
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
+
+from .base import MemoryEntry, MemoryType
 
 
 @dataclass
 class EpisodicEntry:
-    """A single episodic memory entry."""
+    """A single episodic memory entry (session observation)."""
 
     id: str
     timestamp: datetime
     content: str
-    importance: float  # 0.0 - 1.0
+    importance: float  # 0.0 – 1.0
     embedding: list[float] | None = None
     tags: list[str] | None = None
+    access_count: int = 0
+    last_accessed: datetime | None = None
+
+    def record_access(self) -> None:
+        self.access_count += 1
+        self.last_accessed = datetime.now(timezone.utc)
+
+    def to_memory_entry(self) -> MemoryEntry:
+        return MemoryEntry(
+            id=self.id,
+            type=MemoryType.EPISODIC,
+            content=self.content,
+            timestamp=self.timestamp,
+            importance=self.importance,
+            embedding=self.embedding,
+            access_count=self.access_count,
+            last_accessed=self.last_accessed,
+            metadata={"tags": self.tags or []},
+        )
+
+    @classmethod
+    def from_memory_entry(cls, me: MemoryEntry) -> EpisodicEntry:
+        return cls(
+            id=me.id,
+            timestamp=me.timestamp,
+            content=me.content,
+            importance=me.importance,
+            embedding=me.embedding,
+            tags=me.metadata.get("tags"),
+            access_count=me.access_count,
+            last_accessed=me.last_accessed,
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "timestamp": self.timestamp.isoformat(),
+            "content": self.content,
+            "importance": self.importance,
+            "embedding": self.embedding,
+            "tags": self.tags,
+            "access_count": self.access_count,
+            "last_accessed": (
+                self.last_accessed.isoformat() if self.last_accessed else None
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> EpisodicEntry:
+        ts = data["timestamp"]
+        if isinstance(ts, str):
+            ts = datetime.fromisoformat(ts)
+        last_accessed = data.get("last_accessed")
+        if isinstance(last_accessed, str):
+            last_accessed = datetime.fromisoformat(last_accessed)
+        return cls(
+            id=data["id"],
+            timestamp=ts,
+            content=data["content"],
+            importance=data.get("importance", 0.5),
+            embedding=data.get("embedding"),
+            tags=data.get("tags"),
+            access_count=data.get("access_count", 0),
+            last_accessed=last_accessed,
+        )
 
 
 class EpisodicMemory:
     """Session-level, short-term memory store.
 
-    Stores recent observations, conversation snippets, and
-    ephemeral facts that don't persist across sessions.
+    Stores recent observations, conversation snippets, and ephemeral
+    facts that don't need to persist across sessions. Backed by a
+    JSON file for durability within a session.
     """
 
     def __init__(self, storage_path: str | None = None):
         self.storage_path = storage_path or "data/episodic.json"
+        self._entries: dict[str, EpisodicEntry] = {}
+        self._load()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _load(self) -> None:
+        """Load entries from the JSON file if it exists."""
+        path = Path(self.storage_path)
+        if path.exists():
+            try:
+                with open(path, encoding="utf-8") as fh:
+                    data = json.load(fh)
+                self._entries = {
+                    d["id"]: EpisodicEntry.from_dict(d) for d in data
+                }
+            except (json.JSONDecodeError, KeyError, ValueError):
+                # Corrupt file – start fresh
+                self._entries = {}
+
+    def _save(self) -> None:
+        """Persist all entries to the JSON file."""
+        path = Path(self.storage_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = [entry.to_dict() for entry in self._entries.values()]
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, ensure_ascii=False)
+
+    def _generate_id(self) -> str:
+        return f"ep_{uuid.uuid4().hex}"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def add(
-        self, content: str, importance: float = 0.5, tags: list[str] | None = None
+        self,
+        content: str,
+        importance: float = 0.5,
+        tags: list[str] | None = None,
+        embedding: list[float] | None = None,
     ) -> EpisodicEntry:
-        """Add an episodic memory entry."""
+        """Add an episodic memory entry.
+
+        Parameters
+        ----------
+        content : str
+            The observation or fact to store.
+        importance : float
+            Significance in [0.0, 1.0]. Higher values survive pruning.
+        tags : list[str] | None
+            Optional labels for filtering.
+        embedding : list[float] | None
+            Optional vector representation.
+
+        Returns
+        -------
+        EpisodicEntry
+            The newly created entry.
+        """
         entry = EpisodicEntry(
-            id=f"ep_{datetime.now(timezone.utc).timestamp()}",
+            id=self._generate_id(),
             timestamp=datetime.now(timezone.utc),
             content=content,
             importance=importance,
-            tags=tags,
+            tags=tags or [],
+            embedding=embedding,
         )
+        self._entries[entry.id] = entry
+        self._save()
         return entry
 
-    def query(self, query: str, limit: int = 10) -> list[EpisodicEntry]:
-        """Query episodic memory."""
-        return []
+    def get(self, entry_id: str) -> EpisodicEntry | None:
+        """Retrieve a specific entry and record the access."""
+        entry = self._entries.get(entry_id)
+        if entry is not None:
+            entry.record_access()
+            self._save()
+        return entry
+
+    def query(
+        self,
+        query: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 10,
+    ) -> list[EpisodicEntry]:
+        """Return recent entries, optionally filtered by tags.
+
+        Parameters
+        ----------
+        query : str | None
+            If provided, performs a simple text-in-content match.
+        tags : list[str] | None
+            If provided, entries must contain all of these tags.
+        limit : int
+            Maximum number of entries to return (most recent first).
+
+        Returns
+        -------
+        list[EpisodicEntry]
+        """
+        results: list[EpisodicEntry] = []
+        for entry in self._entries.values():
+            if tags and not all(t in (entry.tags or []) for t in tags):
+                continue
+            if query and query.lower() not in entry.content.lower():
+                continue
+            results.append(entry)
+
+        # Sort most recent first, then by importance as tiebreaker
+        results.sort(key=lambda e: (e.timestamp, e.importance), reverse=True)
+        return results[:limit]
+
+    def update(self, entry_id: str, **fields: object) -> EpisodicEntry | None:
+        """Update mutable fields on an existing entry."""
+        entry = self._entries.get(entry_id)
+        if entry is None:
+            return None
+        for key, value in fields.items():
+            if hasattr(entry, key):
+                setattr(entry, key, value)
+        self._save()
+        return entry
 
     def prune(self, max_entries: int = 1000) -> int:
-        """Remove low-importance entries when limit is exceeded."""
-        return 0
+        """Remove the lowest-importance entries until below ``max_entries``.
+
+        Parameters
+        ----------
+        max_entries : int
+            Target maximum size. Entries below the importance threshold
+            are removed oldest-first within their importance band.
+
+        Returns
+        -------
+        int
+            Number of entries removed.
+        """
+        if len(self._entries) <= max_entries:
+            return 0
+
+        # Sort by (importance asc, timestamp asc) – drop lowest importance first
+        sorted_entries = sorted(
+            self._entries.values(), key=lambda e: (e.importance, e.timestamp)
+        )
+        to_remove = len(self._entries) - max_entries
+        removed = 0
+        for entry in sorted_entries:
+            if removed >= to_remove:
+                break
+            del self._entries[entry.id]
+            removed += 1
+
+        self._save()
+        return removed
+
+    def delete(self, entry_id: str) -> bool:
+        """Remove a specific entry by id. Returns True if it existed."""
+        if entry_id in self._entries:
+            del self._entries[entry_id]
+            self._save()
+            return True
+        return False
+
+    def stats(self) -> dict:
+        """Return summary statistics for the store."""
+        if not self._entries:
+            return {"total": 0, "avg_importance": 0.0, "by_tag": {}}
+        total = len(self._entries)
+        avg_imp = sum(e.importance for e in self._entries.values()) / total
+        by_tag: dict[str, int] = {}
+        for entry in self._entries.values():
+            for tag in entry.tags or []:
+                by_tag[tag] = by_tag.get(tag, 0) + 1
+        return {"total": total, "avg_importance": avg_imp, "by_tag": by_tag}
+
+    def clear(self) -> None:
+        """Remove all entries."""
+        self._entries.clear()
+        self._save()

--- a/src/riks_context_engine/memory/procedural.py
+++ b/src/riks_context_engine/memory/procedural.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -25,6 +26,10 @@ class Procedure:
     success_rate: float = 1.0  # 0.0 – 1.0
     tags: list[str] = field(default_factory=list)
     metadata: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.success_rate = max(0.0, min(1.0, float(self.success_rate)))
+        self.use_count = max(0, int(self.use_count))
 
     def record_use(self, success: bool) -> None:
         """Update usage statistics after a run."""
@@ -65,9 +70,11 @@ class Procedure:
             use_count=meta.get("use_count", 0),
             success_rate=meta.get("success_rate", 1.0),
             tags=meta.get("tags", []),
-            metadata={k: v for k, v in meta.items() if k not in (
-                "name", "steps", "use_count", "success_rate", "tags"
-            )},
+            metadata={
+                k: v
+                for k, v in meta.items()
+                if k not in ("name", "steps", "use_count", "success_rate", "tags")
+            },
         )
 
     def to_dict(self) -> dict:
@@ -122,9 +129,7 @@ class ProceduralMemory:
             try:
                 with open(path, encoding="utf-8") as fh:
                     data = json.load(fh)
-                self._procedures = {
-                    d["id"]: Procedure.from_dict(d) for d in data
-                }
+                self._procedures = {d["id"]: Procedure.from_dict(d) for d in data}
             except (json.JSONDecodeError, KeyError, ValueError):
                 self._procedures = {}
 
@@ -132,8 +137,12 @@ class ProceduralMemory:
         path = Path(self.storage_path)
         path.parent.mkdir(parents=True, exist_ok=True)
         data = [p.to_dict() for p in self._procedures.values()]
-        with open(path, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, indent=2, ensure_ascii=False)
+        json_bytes = json.dumps(data, indent=2, ensure_ascii=False).encode("utf-8")
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, json_bytes)
+        finally:
+            os.close(fd)
 
     def _generate_id(self) -> str:
         return f"pr_{uuid.uuid4().hex}"
@@ -242,9 +251,7 @@ class ProceduralMemory:
         self._save()
         return True
 
-    def update(
-        self, proc_id: str, **fields: object
-    ) -> Procedure | None:
+    def update(self, proc_id: str, **fields: object) -> Procedure | None:
         """Update mutable fields on an existing procedure."""
         proc = self._procedures.get(proc_id)
         if proc is None:

--- a/src/riks_context_engine/memory/procedural.py
+++ b/src/riks_context_engine/memory/procedural.py
@@ -1,7 +1,14 @@
 """Procedural memory - skills, workflows, how-to knowledge."""
 
-from dataclasses import dataclass
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
+
+from .base import MemoryEntry, MemoryType
 
 
 @dataclass
@@ -15,36 +22,265 @@ class Procedure:
     created_at: datetime
     last_used: datetime
     use_count: int = 0
-    success_rate: float = 1.0  # 0.0 - 1.0
+    success_rate: float = 1.0  # 0.0 – 1.0
+    tags: list[str] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+    def record_use(self, success: bool) -> None:
+        """Update usage statistics after a run."""
+        self.use_count += 1
+        self.last_used = datetime.now(timezone.utc)
+        # Running mean update
+        prev = self.success_rate
+        n = self.use_count
+        self.success_rate = (prev * (n - 1) + (1.0 if success else 0.0)) / n
+
+    def to_memory_entry(self) -> MemoryEntry:
+        return MemoryEntry(
+            id=self.id,
+            type=MemoryType.PROCEDURAL,
+            content=self.description,
+            timestamp=self.created_at,
+            importance=self.success_rate,
+            metadata={
+                "name": self.name,
+                "steps": self.steps,
+                "use_count": self.use_count,
+                "success_rate": self.success_rate,
+                "tags": self.tags,
+                **self.metadata,
+            },
+        )
+
+    @classmethod
+    def from_memory_entry(cls, me: MemoryEntry) -> Procedure:
+        meta = me.metadata
+        return cls(
+            id=me.id,
+            name=meta.get("name", me.content[:40]),
+            description=me.content,
+            steps=meta.get("steps", []),
+            created_at=me.timestamp,
+            last_used=me.last_accessed or me.timestamp,
+            use_count=meta.get("use_count", 0),
+            success_rate=meta.get("success_rate", 1.0),
+            tags=meta.get("tags", []),
+            metadata={k: v for k, v in meta.items() if k not in (
+                "name", "steps", "use_count", "success_rate", "tags"
+            )},
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "steps": self.steps,
+            "created_at": self.created_at.isoformat(),
+            "last_used": self.last_used.isoformat(),
+            "use_count": self.use_count,
+            "success_rate": self.success_rate,
+            "tags": self.tags,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Procedure:
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            description=data["description"],
+            steps=data["steps"],
+            created_at=datetime.fromisoformat(data["created_at"]),
+            last_used=datetime.fromisoformat(data["last_used"]),
+            use_count=data.get("use_count", 0),
+            success_rate=data.get("success_rate", 1.0),
+            tags=data.get("tags", []),
+            metadata=data.get("metadata", {}),
+        )
 
 
 class ProceduralMemory:
     """Stores skills, workflows, and how-to knowledge.
 
-    Captures how to perform tasks so they can be recalled
-    and reused without relearning.
+    Captures how to perform tasks so they can be recalled and reused
+    without relearning. Backed by a JSON file.
     """
 
     def __init__(self, storage_path: str | None = None):
         self.storage_path = storage_path or "data/procedural.json"
+        self._procedures: dict[str, Procedure] = {}
+        self._load()
 
-    def store(self, name: str, description: str, steps: list[str]) -> Procedure:
-        """Store a new procedure."""
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _load(self) -> None:
+        path = Path(self.storage_path)
+        if path.exists():
+            try:
+                with open(path, encoding="utf-8") as fh:
+                    data = json.load(fh)
+                self._procedures = {
+                    d["id"]: Procedure.from_dict(d) for d in data
+                }
+            except (json.JSONDecodeError, KeyError, ValueError):
+                self._procedures = {}
+
+    def _save(self) -> None:
+        path = Path(self.storage_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = [p.to_dict() for p in self._procedures.values()]
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, ensure_ascii=False)
+
+    def _generate_id(self) -> str:
+        return f"pr_{uuid.uuid4().hex}"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def store(
+        self,
+        name: str,
+        description: str,
+        steps: list[str],
+        tags: list[str] | None = None,
+        metadata: dict | None = None,
+    ) -> Procedure:
+        """Store a new procedure.
+
+        Parameters
+        ----------
+        name : str
+            Human-readable name for the procedure.
+        description : str
+            What this procedure accomplishes.
+        steps : list[str]
+            Ordered list of how to execute the procedure.
+        tags : list[str] | None
+            Labels for categorisation and lookup.
+        metadata : dict | None
+            Additional structured data.
+
+        Returns
+        -------
+        Procedure
+        """
         now = datetime.now(timezone.utc)
         proc = Procedure(
-            id=f"pr_{now.timestamp()}",
+            id=self._generate_id(),
             name=name,
             description=description,
             steps=steps,
             created_at=now,
             last_used=now,
+            tags=tags or [],
+            metadata=metadata or {},
         )
+        self._procedures[proc.id] = proc
+        self._save()
         return proc
 
+    def get(self, proc_id: str) -> Procedure | None:
+        """Retrieve a procedure by id."""
+        return self._procedures.get(proc_id)
+
     def recall(self, name: str) -> Procedure | None:
-        """Recall a procedure by name."""
+        """Recall a procedure by exact name match (case-insensitive)."""
+        name_lower = name.lower()
+        for proc in self._procedures.values():
+            if proc.name.lower() == name_lower:
+                return proc
         return None
 
-    def find(self, query: str) -> list[Procedure]:
-        """Find procedures matching a query."""
-        return []
+    def find(
+        self,
+        query: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 10,
+    ) -> list[Procedure]:
+        """Find procedures matching a query and/or tags.
+
+        Parameters
+        ----------
+        query : str | None
+            Text match against name and description (case-insensitive).
+        tags : list[str] | None
+            Procedures must contain all of these tags.
+        limit : int
+            Maximum results to return (sorted by success_rate desc).
+
+        Returns
+        -------
+        list[Procedure]
+        """
+        results: list[Procedure] = []
+        for proc in self._procedures.values():
+            if tags and not all(t in proc.tags for t in tags):
+                continue
+            if query:
+                ql = query.lower()
+                if ql not in proc.name.lower() and ql not in proc.description.lower():
+                    continue
+            results.append(proc)
+
+        results.sort(key=lambda p: (p.success_rate, p.use_count), reverse=True)
+        return results[:limit]
+
+    def record_execution(self, proc_id: str, success: bool) -> bool:
+        """Record the outcome of executing a procedure.
+
+        Returns True if the procedure was found and updated.
+        """
+        proc = self._procedures.get(proc_id)
+        if proc is None:
+            return False
+        proc.record_use(success)
+        self._save()
+        return True
+
+    def update(
+        self, proc_id: str, **fields: object
+    ) -> Procedure | None:
+        """Update mutable fields on an existing procedure."""
+        proc = self._procedures.get(proc_id)
+        if proc is None:
+            return None
+        for key, value in fields.items():
+            if hasattr(proc, key):
+                setattr(proc, key, value)
+        self._save()
+        return proc
+
+    def delete(self, proc_id: str) -> bool:
+        """Remove a procedure. Returns True if it existed."""
+        if proc_id in self._procedures:
+            del self._procedures[proc_id]
+            self._save()
+            return True
+        return False
+
+    def stats(self) -> dict:
+        if not self._procedures:
+            return {"total": 0, "avg_success_rate": 0.0, "by_tag": {}}
+        total = len(self._procedures)
+        avg_sr = sum(p.success_rate for p in self._procedures.values()) / total
+        total_uses = sum(p.use_count for p in self._procedures.values())
+        by_tag: dict[str, int] = {}
+        for proc in self._procedures.values():
+            for tag in proc.tags:
+                by_tag[tag] = by_tag.get(tag, 0) + 1
+        return {
+            "total": total,
+            "avg_success_rate": avg_sr,
+            "total_uses": total_uses,
+            "by_tag": by_tag,
+        }
+
+    def clear(self) -> None:
+        """Remove all procedures."""
+        self._procedures.clear()
+        self._save()

--- a/src/riks_context_engine/memory/semantic.py
+++ b/src/riks_context_engine/memory/semantic.py
@@ -1,55 +1,393 @@
-"""Semantic memory - long-term structured knowledge."""
+"""Semantic memory - long-term structured knowledge with vector search."""
 
-from dataclasses import dataclass
+from __future__ import annotations
+
+import math
+import sqlite3
+import uuid
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .base import MemoryEntry, MemoryType
+from .embedding import OllamaEmbedder, get_embedder
 
 
 @dataclass
 class SemanticEntry:
-    """A semantic knowledge entry."""
+    """A semantic knowledge entry (subject–predicate–object triple)."""
 
     id: str
     subject: str
     predicate: str
     object: str | None
-    confidence: float  # 0.0 - 1.0
+    confidence: float  # 0.0 – 1.0
+    embedding: list[float] | None
     created_at: datetime
     last_accessed: datetime
     access_count: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def record_access(self) -> None:
+        self.access_count += 1
+        self.last_accessed = datetime.now(timezone.utc)
+
+    def to_memory_entry(self) -> MemoryEntry:
+        return MemoryEntry(
+            id=self.id,
+            type=MemoryType.SEMANTIC,
+            content=f"{self.subject} {self.predicate} {self.object or ''}".strip(),
+            timestamp=self.created_at,
+            importance=self.confidence,
+            embedding=self.embedding,
+            access_count=self.access_count,
+            last_accessed=self.last_accessed,
+            metadata=self.metadata,
+        )
+
+    @classmethod
+    def from_memory_entry(cls, me: MemoryEntry) -> SemanticEntry:
+        parts = me.content.split(" ", 2)
+        subject = parts[0] if len(parts) > 0 else ""
+        predicate = parts[1] if len(parts) > 1 else ""
+        obj = parts[2] if len(parts) > 2 else None
+        return cls(
+            id=me.id,
+            subject=subject,
+            predicate=predicate,
+            object=obj,
+            confidence=me.importance,
+            embedding=me.embedding,
+            created_at=me.timestamp,
+            last_accessed=me.last_accessed or me.timestamp,
+            access_count=me.access_count,
+            metadata=me.metadata,
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "subject": self.subject,
+            "predicate": self.predicate,
+            "object": self.object,
+            "confidence": self.confidence,
+            "embedding": self.embedding,
+            "created_at": self.created_at.isoformat(),
+            "last_accessed": self.last_accessed.isoformat(),
+            "access_count": self.access_count,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> SemanticEntry:
+        return cls(
+            id=data["id"],
+            subject=data["subject"],
+            predicate=data["predicate"],
+            object=data.get("object"),
+            confidence=data.get("confidence", 1.0),
+            embedding=data.get("embedding"),
+            created_at=datetime.fromisoformat(data["created_at"]),
+            last_accessed=datetime.fromisoformat(data["last_accessed"]),
+            access_count=data.get("access_count", 0),
+            metadata=data.get("metadata", {}),
+        )
+
+
+def _cosine_sim(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
 
 
 class SemanticMemory:
-    """Long-term structured knowledge store.
+    """Long-term structured knowledge store with vector search.
 
-    Persists facts, concepts, and relationships that are
-    accessed repeatedly across sessions.
+    Persists facts, concepts, and relationships. Each entry optionally
+    carries a vector embedding for semantic similarity search.
+    Uses SQLite for durable, queryable storage.
     """
 
-    def __init__(self, db_path: str | None = None):
+    _SCHEMA = """
+    CREATE TABLE IF NOT EXISTS semantic_entries (
+        id          TEXT PRIMARY KEY,
+        subject     TEXT NOT NULL,
+        predicate   TEXT NOT NULL,
+        object      TEXT,
+        confidence  REAL NOT NULL DEFAULT 1.0,
+        embedding   BLOB,
+        created_at  TEXT NOT NULL,
+        last_accessed TEXT NOT NULL,
+        access_count INTEGER NOT NULL DEFAULT 0,
+        metadata    TEXT NOT NULL DEFAULT '{}'
+    );
+    CREATE INDEX IF NOT EXISTS idx_semantic_subject ON semantic_entries(subject);
+    CREATE INDEX IF NOT EXISTS idx_semantic_predicate ON semantic_entries(predicate);
+    """
+
+    def __init__(
+        self,
+        db_path: str | None = None,
+        embedder: OllamaEmbedder | None = None,
+        embedding_dim: int = 768,
+    ):
         self.db_path = db_path or "data/semantic.db"
+        self._embedder = embedder
+        self.embedding_dim = embedding_dim
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    # Database helpers
+    # ------------------------------------------------------------------
+
+    def _init_db(self) -> None:
+        path = Path(self.db_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with self._conn() as conn:
+            conn.executescript(self._SCHEMA)
+            conn.commit()
+
+    @contextmanager
+    def _conn(self) -> Generator[sqlite3.Connection, None, None]:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def _generate_id(self) -> str:
+        return f"sm_{uuid.uuid4().hex}"
+
+    @property
+    def embedder(self) -> OllamaEmbedder:
+        if self._embedder is None:
+            self._embedder = get_embedder()
+        return self._embedder
+
+    def set_embedder(self, embedder: OllamaEmbedder) -> None:
+        self._embedder = embedder
+
+    # ------------------------------------------------------------------
+    # Core CRUD
+    # ------------------------------------------------------------------
 
     def add(
-        self, subject: str, predicate: str, object: str | None = None, confidence: float = 1.0
+        self,
+        subject: str,
+        predicate: str,
+        object: str | None = None,
+        confidence: float = 1.0,
+        generate_embedding: bool = True,
     ) -> SemanticEntry:
-        """Add a semantic knowledge entry."""
+        """Add a semantic knowledge entry.
+
+        Parameters
+        ----------
+        subject, predicate, object : str
+            The subject–predicate–[object] triple.
+        confidence : float
+            How certain this fact is (0.0–1.0), also used as importance.
+        generate_embedding : bool
+            If True, call the Ollama embedder to generate a vector.
+
+        Returns
+        -------
+        SemanticEntry
+        """
         now = datetime.now(timezone.utc)
+        embedding: list[float] | None = None
+        if generate_embedding:
+            text = f"{subject} {predicate} {object or ''}"
+            try:
+                result = self.embedder.embed(text)
+                embedding = result.embedding
+            except Exception:  # pragma: no cover – embedder may be unavailable in tests
+                embedding = None
+
         entry = SemanticEntry(
-            id=f"sm_{now.timestamp()}",
+            id=self._generate_id(),
             subject=subject,
             predicate=predicate,
             object=object,
             confidence=confidence,
+            embedding=embedding,
             created_at=now,
             last_accessed=now,
         )
+        self._upsert(entry)
         return entry
 
-    def query(
-        self, subject: str | None = None, predicate: str | None = None
-    ) -> list[SemanticEntry]:
-        """Query semantic memory."""
-        return []
+    def _upsert(self, entry: SemanticEntry) -> None:
+        with self._conn() as conn:
+            import json
 
-    def recall(self, query: str) -> list[SemanticEntry]:
-        """Semantic search across knowledge."""
-        return []
+            embedding_bytes = (
+                json.dumps(entry.embedding).encode() if entry.embedding else None
+            )
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO semantic_entries
+                (id, subject, predicate, object, confidence, embedding,
+                 created_at, last_accessed, access_count, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry.id,
+                    entry.subject,
+                    entry.predicate,
+                    entry.object,
+                    entry.confidence,
+                    embedding_bytes,
+                    entry.created_at.isoformat(),
+                    entry.last_accessed.isoformat(),
+                    entry.access_count,
+                    json.dumps(entry.metadata),
+                ),
+            )
+            conn.commit()
+
+    def get(self, entry_id: str) -> SemanticEntry | None:
+        """Retrieve an entry by id and record the access."""
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT * FROM semantic_entries WHERE id = ?", (entry_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        entry = self._row_to_entry(row)
+        entry.record_access()
+        self._upsert(entry)
+        return entry
+
+    def _row_to_entry(self, row: sqlite3.Row) -> SemanticEntry:
+        import json
+
+        embedding_bytes = row["embedding"]
+        embedding: list[float] | None = None
+        if embedding_bytes:
+            embedding = json.loads(embedding_bytes.decode())
+        return SemanticEntry(
+            id=row["id"],
+            subject=row["subject"],
+            predicate=row["predicate"],
+            object=row["object"],
+            confidence=row["confidence"],
+            embedding=embedding,
+            created_at=datetime.fromisoformat(row["created_at"]),
+            last_accessed=datetime.fromisoformat(row["last_accessed"]),
+            access_count=row["access_count"],
+            metadata=json.loads(row["metadata"]) if row["metadata"] else {},
+        )
+
+    def query(
+        self,
+        subject: str | None = None,
+        predicate: str | None = None,
+        object: str | None = None,
+        limit: int = 20,
+    ) -> list[SemanticEntry]:
+        """Query by exact triple components (ANDed filters)."""
+        conditions: list[str] = []
+        params: list[Any] = []
+        if subject:
+            conditions.append("subject = ?")
+            params.append(subject)
+        if predicate:
+            conditions.append("predicate = ?")
+            params.append(predicate)
+        if object:
+            conditions.append("object = ?")
+            params.append(object)
+        where = " AND ".join(conditions) if conditions else "1=1"
+
+        with self._conn() as conn:
+            rows = conn.execute(
+                f"SELECT * FROM semantic_entries WHERE {where} LIMIT ?",
+                [*params, limit],
+            ).fetchall()
+        return [self._row_to_entry(r) for r in rows]
+
+    def recall(
+        self,
+        query: str,
+        limit: int = 5,
+        min_similarity: float = 0.0,
+    ) -> list[tuple[SemanticEntry, float]]:
+        """Semantic search: find entries most similar to the query string.
+
+        Returns entries sorted by cosine similarity to the query embedding,
+        dropping those below ``min_similarity``.
+        """
+        try:
+            query_emb = self.embedder.embed(query).embedding
+        except Exception:  # pragma: no cover – embedder may be unavailable
+            return []
+
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT * FROM semantic_entries WHERE embedding IS NOT NULL"
+            ).fetchall()
+
+        scored: list[tuple[SemanticEntry, float]] = []
+        for row in rows:
+            entry = self._row_to_entry(row)
+            if entry.embedding:
+                sim = _cosine_sim(query_emb, entry.embedding)
+                if sim >= min_similarity:
+                    entry.record_access()
+                    self._upsert(entry)
+                    scored.append((entry, sim))
+
+        scored.sort(key=lambda x: x[1], reverse=True)
+        return scored[:limit]
+
+    def update(
+        self, entry_id: str, **fields: Any
+    ) -> SemanticEntry | None:
+        """Update mutable fields on an existing entry."""
+        entry = self.get(entry_id)
+        if entry is None:
+            return None
+        for key, value in fields.items():
+            if hasattr(entry, key):
+                setattr(entry, key, value)
+        self._upsert(entry)
+        return entry
+
+    def delete(self, entry_id: str) -> bool:
+        with self._conn() as conn:
+            cur = conn.execute(
+                "DELETE FROM semantic_entries WHERE id = ?", (entry_id,)
+            )
+            conn.commit()
+            return cur.rowcount > 0
+
+    def stats(self) -> dict:
+        with self._conn() as conn:
+            total = conn.execute(
+                "SELECT COUNT(*) FROM semantic_entries"
+            ).fetchone()[0]
+            avg_conf = conn.execute(
+                "SELECT AVG(confidence) FROM semantic_entries"
+            ).fetchone()[0] or 0.0
+            with_emb = conn.execute(
+                "SELECT COUNT(*) FROM semantic_entries WHERE embedding IS NOT NULL"
+            ).fetchone()[0]
+        return {
+            "total": total,
+            "avg_confidence": avg_conf,
+            "with_embedding": with_emb,
+        }
+
+    def clear(self) -> None:
+        with self._conn() as conn:
+            conn.execute("DELETE FROM semantic_entries")
+            conn.commit()

--- a/src/riks_context_engine/memory/semantic.py
+++ b/src/riks_context_engine/memory/semantic.py
@@ -31,6 +31,10 @@ class SemanticEntry:
     access_count: int = 0
     metadata: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        self.confidence = max(0.0, min(1.0, float(self.confidence)))
+        self.access_count = max(0, int(self.access_count))
+
     def record_access(self) -> None:
         self.access_count += 1
         self.last_accessed = datetime.now(timezone.utc)
@@ -229,9 +233,7 @@ class SemanticMemory:
         with self._conn() as conn:
             import json
 
-            embedding_bytes = (
-                json.dumps(entry.embedding).encode() if entry.embedding else None
-            )
+            embedding_bytes = json.dumps(entry.embedding).encode() if entry.embedding else None
             conn.execute(
                 """
                 INSERT OR REPLACE INTO semantic_entries
@@ -349,9 +351,7 @@ class SemanticMemory:
         scored.sort(key=lambda x: x[1], reverse=True)
         return scored[:limit]
 
-    def update(
-        self, entry_id: str, **fields: Any
-    ) -> SemanticEntry | None:
+    def update(self, entry_id: str, **fields: Any) -> SemanticEntry | None:
         """Update mutable fields on an existing entry."""
         entry = self.get(entry_id)
         if entry is None:
@@ -364,20 +364,16 @@ class SemanticMemory:
 
     def delete(self, entry_id: str) -> bool:
         with self._conn() as conn:
-            cur = conn.execute(
-                "DELETE FROM semantic_entries WHERE id = ?", (entry_id,)
-            )
+            cur = conn.execute("DELETE FROM semantic_entries WHERE id = ?", (entry_id,))
             conn.commit()
             return cur.rowcount > 0
 
     def stats(self) -> dict:
         with self._conn() as conn:
-            total = conn.execute(
-                "SELECT COUNT(*) FROM semantic_entries"
-            ).fetchone()[0]
-            avg_conf = conn.execute(
-                "SELECT AVG(confidence) FROM semantic_entries"
-            ).fetchone()[0] or 0.0
+            total = conn.execute("SELECT COUNT(*) FROM semantic_entries").fetchone()[0]
+            avg_conf = (
+                conn.execute("SELECT AVG(confidence) FROM semantic_entries").fetchone()[0] or 0.0
+            )
             with_emb = conn.execute(
                 "SELECT COUNT(*) FROM semantic_entries WHERE embedding IS NOT NULL"
             ).fetchone()[0]

--- a/src/riks_context_engine/memory/tier_manager.py
+++ b/src/riks_context_engine/memory/tier_manager.py
@@ -1,0 +1,193 @@
+"""TierManager - Automatic promotion/demotion across memory tiers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .base import MemoryType
+
+if TYPE_CHECKING:
+    from .episodic import EpisodicMemory
+    from .procedural import ProceduralMemory
+    from .semantic import SemanticMemory
+
+
+@dataclass
+class TierConfig:
+    """Configuration for automatic tiering."""
+
+    promote_threshold: int = 5
+    """Access count threshold for promoting episodic → semantic."""
+
+    demote_threshold: int = 0
+    """Minimum access count before demoting semantic → episodic (0 = never demote)."""
+
+    max_episodic: int = 1000
+    """Max episodic entries before pruning."""
+
+    check_interval_accesses: int = 10
+    """Run auto_tier every N cumulative accesses (0 = disabled)."""
+
+    _access_counter: int = field(default=0, repr=False)
+
+    def should_run(self) -> bool:
+        if self.check_interval_accesses == 0:
+            return False
+        self._access_counter += 1
+        if self._access_counter >= self.check_interval_accesses:
+            self._access_counter = 0
+            return True
+        return False
+
+
+class TierManager:
+    """Manages automatic promotion and demotion across memory tiers.
+
+    Monitors access frequency across episodic and semantic stores and
+    promotes frequently-accessed episodic entries to semantic memory,
+    or demotes stale semantic entries back to episodic.
+
+    Parameters
+    ----------
+    episodic : EpisodicMemory
+        The episodic memory store.
+    semantic : SemanticMemory
+        The semantic memory store.
+    procedural : ProceduralMemory
+        The procedural memory store (not subject to tiering).
+    config : TierConfig | None
+        Tiering thresholds and behaviour.
+    """
+
+    def __init__(
+        self,
+        episodic: EpisodicMemory,
+        semantic: SemanticMemory,
+        procedural: ProceduralMemory,
+        config: TierConfig | None = None,
+    ) -> None:
+        self.episodic = episodic
+        self.semantic = semantic
+        self.procedural = procedural
+        self.config = config or TierConfig()
+
+    # ------------------------------------------------------------------
+    # Promotion / Demotion helpers
+    # ------------------------------------------------------------------
+
+    def _promote_episodic_entry(self, entry_id: str, threshold: int | None = None) -> bool:
+        """Promote a frequently-accessed episodic entry to semantic memory.
+
+        Returns True if promotion occurred.
+        """
+        cfg = self.config
+        threshold = threshold if threshold is not None else cfg.promote_threshold
+
+        ep_entry = self.episodic.get(entry_id)
+        if ep_entry is None:
+            return False
+
+        if ep_entry.access_count <= threshold:
+            return False
+
+        # Create semantic entry from episodic
+        text = ep_entry.content
+        self.semantic.add(
+            subject=text.split(" ")[0] if text else "unknown",
+            predicate="observed_as",
+            object=text,
+            confidence=ep_entry.importance,
+            generate_embedding=True,
+        )
+
+        # Remove from episodic
+        self.episodic.delete(entry_id)
+        return True
+
+    def _demote_semantic_entry(self, entry_id: str) -> bool:
+        """Demote a semantic entry back to episodic (if access_count is low).
+
+        Returns True if demotion occurred.
+        """
+        sem_entry = self.semantic.get(entry_id)
+        if sem_entry is None:
+            return False
+
+        cfg = self.config
+        if cfg.demote_threshold <= 0:
+            return False
+
+        if sem_entry.access_count >= cfg.demote_threshold:
+            return False
+
+        # Store in episodic
+        self.episodic.add(
+            content=sem_entry.to_memory_entry().content,
+            importance=sem_entry.confidence,
+            tags=[],
+            embedding=sem_entry.embedding,
+        )
+
+        # Remove from semantic
+        self.semantic.delete(entry_id)
+        return True
+
+    # ------------------------------------------------------------------
+    # Main auto_tier entry point
+    # ------------------------------------------------------------------
+
+    def auto_tier(self) -> dict[str, int]:
+        """Run one tiering cycle.
+
+        Promotes high-access-count episodic entries to semantic,
+        demotes low-access-count semantic entries back to episodic.
+
+        Returns
+        -------
+        dict[str, int]
+            Summary with keys ``promoted``, ``demoted``.
+        """
+        promoted = 0
+        demoted = 0
+
+        # Scan episodic entries for promotion candidates
+        for ep_entry in list(self.episodic._entries.values()):
+            if ep_entry.access_count > self.config.promote_threshold:
+                if self._promote_episodic_entry(ep_entry.id):
+                    promoted += 1
+
+        # Scan semantic entries for demotion candidates
+        if self.config.demote_threshold > 0:
+            with self.semantic._conn() as conn:
+                rows = conn.execute("SELECT id FROM semantic_entries").fetchall()
+            for row in rows:
+                if self._demote_semantic_entry(row["id"]):
+                    demoted += 1
+
+        return {"promoted": promoted, "demoted": demoted}
+
+    # ------------------------------------------------------------------
+    # Convenience helpers
+    # ------------------------------------------------------------------
+
+    def record_access(
+        self,
+        memory_type: MemoryType,
+        entry_id: str,
+    ) -> None:
+        """Record an access on an entry and optionally trigger auto_tier.
+
+        Call this whenever an entry is retrieved from any tier.
+        """
+        # Import here to avoid circular imports at module level
+
+        if memory_type == MemoryType.EPISODIC:
+            self.episodic.get(entry_id)
+        elif memory_type == MemoryType.SEMANTIC:
+            self.semantic.get(entry_id)
+        elif memory_type == MemoryType.PROCEDURAL:
+            self.procedural.get(entry_id)
+
+        if self.config.should_run():
+            self.auto_tier()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,41 +1,262 @@
 """Tests for memory module."""
 
-from riks_context_engine.memory.episodic import EpisodicMemory
-from riks_context_engine.memory.procedural import ProceduralMemory
-from riks_context_engine.memory.semantic import SemanticMemory
+import tempfile
 
+import pytest
+
+from riks_context_engine.memory import (
+    EpisodicMemory,
+    MemoryEntry,
+    MemoryType,
+    OllamaEmbedder,
+    OllamaEmbeddingError,
+    ProceduralMemory,
+    SemanticMemory,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def new_temp_path() -> str:
+    return tempfile.mktemp(suffix=".json")
+
+
+def new_temp_db() -> str:
+    return tempfile.mktemp(suffix=".db")
+
+
+# ---------------------------------------------------------------------------
+# MemoryEntry / MemoryType (base)
+# ---------------------------------------------------------------------------
+
+class TestMemoryType:
+    def test_memory_type_values(self):
+        assert MemoryType.EPISODIC.value == "episodic"
+        assert MemoryType.SEMANTIC.value == "semantic"
+        assert MemoryType.PROCEDURAL.value == "procedural"
+
+
+class TestMemoryEntry:
+    def test_record_access_increments_count(self):
+        entry = MemoryEntry(
+            id="test_1",
+            type=MemoryType.EPISODIC,
+            content="hello",
+        )
+        assert entry.access_count == 0
+        entry.record_access()
+        assert entry.access_count == 1
+        assert entry.last_accessed is not None
+
+    def test_to_dict_roundtrip(self):
+        entry = MemoryEntry(
+            id="test_2",
+            type=MemoryType.SEMANTIC,
+            content="Paris is the capital of France",
+            importance=0.95,
+            embedding=[0.1, 0.2, 0.3],
+            metadata={"source": "wikipedia"},
+        )
+        data = entry.to_dict()
+        restored = MemoryEntry.from_dict(data)
+        assert restored.id == entry.id
+        assert restored.type == entry.type
+        assert restored.content == entry.content
+        assert restored.importance == entry.importance
+        assert restored.embedding == entry.embedding
+
+
+# ---------------------------------------------------------------------------
+# EpisodicMemory
+# ---------------------------------------------------------------------------
 
 class TestEpisodicMemory:
     def test_add_entry(self):
-        mem = EpisodicMemory(storage_path=":memory:")
+        mem = EpisodicMemory(storage_path=new_temp_path())
         entry = mem.add(content="Test observation", importance=0.8, tags=["test"])
         assert entry.content == "Test observation"
         assert entry.importance == 0.8
         assert "test" in entry.tags
 
     def test_episodic_entry_has_id(self):
-        mem = EpisodicMemory(storage_path=":memory:")
+        mem = EpisodicMemory(storage_path=new_temp_path())
         entry = mem.add("something happened")
         assert entry.id.startswith("ep_")
 
+    def test_add_persists_to_disk(self):
+        path = new_temp_path()
+        mem = EpisodicMemory(storage_path=path)
+        mem.add("first fact", importance=0.9, tags=["fact"])
+        mem.add("second fact", importance=0.7, tags=["fact"])
+
+        # Re-open – data should survive
+        mem2 = EpisodicMemory(storage_path=path)
+        results = mem2.query(tags=["fact"])
+        assert len(results) == 2
+        contents = {r.content for r in results}
+        assert "first fact" in contents
+        assert "second fact" in contents
+
+    def test_query_by_tag(self):
+        mem = EpisodicMemory(storage_path=new_temp_path())
+        mem.add("alpha", tags=["a", "common"])
+        mem.add("beta", tags=["b", "common"])
+        mem.add("gamma", tags=["a"])
+
+        results = mem.query(tags=["a"])
+        assert len(results) == 2
+        contents = {r.content for r in results}
+        assert "alpha" in contents
+        assert "gamma" in contents
+        assert "beta" not in contents
+
+    def test_query_by_text(self):
+        mem = EpisodicMemory(storage_path=new_temp_path())
+        mem.add("The sky is blue today")
+        mem.add("Roses are red")
+        results = mem.query(query="blue")
+        assert len(results) == 1
+        assert results[0].content == "The sky is blue today"
+
+    def test_prune_removes_low_importance(self):
+        mem = EpisodicMemory(storage_path=new_temp_path())
+        for i in range(10):
+            mem.add(f"fact {i}", importance=i / 10.0)
+        assert len(mem._entries) == 10
+        removed = mem.prune(max_entries=5)
+        assert removed == 5
+        assert len(mem._entries) == 5
+        # Remaining should be the highest importance ones
+        remaining = list(mem._entries.values())
+        assert all(e.importance >= 0.5 for e in remaining)
+
+    def test_delete_entry(self):
+        mem = EpisodicMemory(storage_path=new_temp_path())
+        entry = mem.add("to delete")
+        assert mem.delete(entry.id) is True
+        assert mem.delete(entry.id) is False  # already gone
+
+    def test_get_records_access(self):
+        mem = EpisodicMemory(storage_path=new_temp_path())
+        entry = mem.add("remember this")
+        first_access = entry.access_count
+        retrieved = mem.get(entry.id)
+        assert retrieved is not None
+        assert retrieved.access_count == first_access + 1
+
+    def test_stats(self):
+        mem = EpisodicMemory(storage_path=new_temp_path())
+        mem.add("alpha", importance=0.5, tags=["tag_a"])
+        mem.add("beta", importance=0.6, tags=["tag_a"])
+        mem.add("gamma", importance=0.7, tags=["tag_b"])
+        stats = mem.stats()
+        assert stats["total"] == 3
+        assert stats["avg_importance"] == pytest.approx(0.6)
+        assert stats["by_tag"]["tag_a"] == 2
+
+    def test_clear(self):
+        mem = EpisodicMemory(storage_path=new_temp_path())
+        mem.add("one")
+        mem.add("two")
+        mem.clear()
+        assert len(mem._entries) == 0
+
+    def test_to_memory_entry_roundtrip(self):
+        mem = EpisodicMemory(storage_path=new_temp_path())
+        entry = mem.add("hello world", importance=0.8, tags=["greeting"])
+        me = entry.to_memory_entry()
+        assert me.type == MemoryType.EPISODIC
+        assert me.content == "hello world"
+        assert me.metadata["tags"] == ["greeting"]
+
+
+# ---------------------------------------------------------------------------
+# SemanticMemory
+# ---------------------------------------------------------------------------
 
 class TestSemanticMemory:
     def test_add_entry(self):
-        mem = SemanticMemory(db_path=":memory:")
-        entry = mem.add(subject="Rik", predicate="is", object="an AI assistant", confidence=0.95)
+        mem = SemanticMemory(db_path=new_temp_db())
+        entry = mem.add(
+            subject="Rik",
+            predicate="is",
+            object="an AI assistant",
+            confidence=0.95,
+            generate_embedding=False,
+        )
         assert entry.subject == "Rik"
         assert entry.predicate == "is"
         assert entry.confidence == 0.95
 
     def test_access_count_increments(self):
-        mem = SemanticMemory(db_path=":memory:")
-        entry = mem.add("Vahit", "works at", "opsiton")
+        mem = SemanticMemory(db_path=new_temp_db())
+        entry = mem.add("Vahit", "works at", "opsiton", generate_embedding=False)
         assert entry.access_count == 0
+        _ = mem.get(entry.id)
+        retrieved = mem.get(entry.id)
+        assert retrieved is not None
+        assert retrieved.access_count == 2
 
+    def test_query_by_subject(self):
+        mem = SemanticMemory(db_path=new_temp_db())
+        mem.add("Paris", "capital of", "France", generate_embedding=False)
+        mem.add("London", "capital of", "UK", generate_embedding=False)
+        results = mem.query(subject="Paris")
+        assert len(results) == 1
+        assert results[0].object == "France"
+
+    def test_query_by_predicate(self):
+        mem = SemanticMemory(db_path=new_temp_db())
+        mem.add("Alice", "knows", "Bob", generate_embedding=False)
+        mem.add("Bob", "knows", "Carol", generate_embedding=False)
+        results = mem.query(predicate="knows")
+        assert len(results) == 2
+
+    def test_delete_entry(self):
+        mem = SemanticMemory(db_path=new_temp_db())
+        entry = mem.add("Test", "delete me", "row", generate_embedding=False)
+        assert mem.delete(entry.id) is True
+        assert mem.get(entry.id) is None
+
+    def test_stats(self):
+        mem = SemanticMemory(db_path=new_temp_db())
+        mem.add("A", "B", "C", confidence=0.8, generate_embedding=False)
+        mem.add("D", "E", "F", confidence=0.9, generate_embedding=False)
+        stats = mem.stats()
+        assert stats["total"] == 2
+        assert stats["avg_confidence"] == pytest.approx(0.85)
+        assert stats["with_embedding"] == 0  # no embeddings generated
+
+    def test_clear(self):
+        mem = SemanticMemory(db_path=new_temp_db())
+        mem.add("X", "Y", "Z", generate_embedding=False)
+        mem.clear()
+        assert mem.stats()["total"] == 0
+
+    def test_recall_requires_embedder(self):
+        """recall() should return [] gracefully if embedder is unavailable."""
+        mem = SemanticMemory(db_path=new_temp_db())
+        mem.add("alpha", "beta", "gamma", generate_embedding=False)
+        # No embedder set – recall should return empty without crashing
+        results = mem.recall("anything")
+        assert results == []
+
+    def test_to_memory_entry_roundtrip(self):
+        mem = SemanticMemory(db_path=new_temp_db())
+        entry = mem.add("Vahit", "lives in", "Istanbul", generate_embedding=False)
+        me = entry.to_memory_entry()
+        assert me.type == MemoryType.SEMANTIC
+        assert "Vahit" in me.content
+
+
+# ---------------------------------------------------------------------------
+# ProceduralMemory
+# ---------------------------------------------------------------------------
 
 class TestProceduralMemory:
     def test_store_procedure(self):
-        mem = ProceduralMemory(storage_path=":memory:")
+        mem = ProceduralMemory(storage_path=new_temp_path())
         proc = mem.store(
             name="Deploy Service",
             description="Deploy a microservice to Kubernetes",
@@ -46,6 +267,148 @@ class TestProceduralMemory:
         assert proc.use_count == 0
 
     def test_procedure_has_id(self):
-        mem = ProceduralMemory(storage_path=":memory:")
+        mem = ProceduralMemory(storage_path=new_temp_path())
         proc = mem.store("Test Proc", "A test", ["step1"])
         assert proc.id.startswith("pr_")
+
+    def test_store_persists_to_disk(self):
+        path = new_temp_path()
+        mem = ProceduralMemory(storage_path=path)
+        mem.store("Build Image", "Build docker image", ["docker build"])
+        mem2 = ProceduralMemory(storage_path=path)
+        results = mem2.find(query="docker")
+        assert len(results) == 1
+        assert results[0].name == "Build Image"
+
+    def test_recall_by_name(self):
+        mem = ProceduralMemory(storage_path=new_temp_path())
+        mem.store("Send Email", "Send an email", ["compose", "send"])
+        result = mem.recall("Send Email")
+        assert result is not None
+        assert result.name == "Send Email"
+
+    def test_recall_case_insensitive(self):
+        mem = ProceduralMemory(storage_path=new_temp_path())
+        mem.store("Deploy Service", "Deploy a service", ["step1"])
+        assert mem.recall("deploy service") is not None
+
+    def test_find_by_tag(self):
+        mem = ProceduralMemory(storage_path=new_temp_path())
+        mem.store("Alpha", "A proc", ["s1"], tags=["dev", "infra"])
+        mem.store("Beta", "B proc", ["s2"], tags=["dev"])
+        mem.store("Gamma", "C proc", ["s3"], tags=["infra"])
+        results = mem.find(tags=["infra"])
+        assert len(results) == 2
+        names = {r.name for r in results}
+        assert "Alpha" in names
+        assert "Gamma" in names
+
+    def test_find_by_query(self):
+        mem = ProceduralMemory(storage_path=new_temp_path())
+        mem.store("Send Email", "Send email via SMTP", ["connect", "send"])
+        mem.store("Send SMS", "Send SMS via API", ["prepare", "send"])
+        results = mem.find(query="email")
+        assert len(results) == 1
+        assert results[0].name == "Send Email"
+
+    def test_record_execution_updates_stats(self):
+        mem = ProceduralMemory(storage_path=new_temp_path())
+        proc = mem.store("Test", "Test procedure", ["step1"])
+        assert proc.success_rate == 1.0
+        assert proc.use_count == 0
+        mem.record_execution(proc.id, success=True)
+        updated = mem.get(proc.id)
+        assert updated is not None
+        assert updated.use_count == 1
+        assert updated.success_rate == 1.0
+        mem.record_execution(proc.id, success=False)
+        updated2 = mem.get(proc.id)
+        assert updated2 is not None
+        assert updated2.use_count == 2
+        assert updated2.success_rate == pytest.approx(0.5)
+
+    def test_delete_procedure(self):
+        mem = ProceduralMemory(storage_path=new_temp_path())
+        proc = mem.store("Temp", "Temporary", ["s1"])
+        assert mem.delete(proc.id) is True
+        assert mem.delete(proc.id) is False
+        assert mem.recall("Temp") is None
+
+    def test_stats(self):
+        mem = ProceduralMemory(storage_path=new_temp_path())
+        mem.store("Alpha", "A", ["s1"], tags=["x"])
+        mem.store("Beta", "B", ["s2"], tags=["x", "y"])
+        mem.store("Gamma", "G", ["s3"], tags=["y"])
+        stats = mem.stats()
+        assert stats["total"] == 3
+        assert stats["avg_success_rate"] == 1.0  # all new = 1.0
+        assert stats["by_tag"]["x"] == 2
+        assert stats["by_tag"]["y"] == 2
+
+    def test_to_memory_entry_roundtrip(self):
+        mem = ProceduralMemory(storage_path=new_temp_path())
+        proc = mem.store("Deploy", "Deploy to k8s", ["build", "push", "apply"], tags=["k8s"])
+        me = proc.to_memory_entry()
+        assert me.type == MemoryType.PROCEDURAL
+        assert me.metadata["name"] == "Deploy"
+        assert me.metadata["steps"] == ["build", "push", "apply"]
+        assert me.metadata["tags"] == ["k8s"]
+
+
+# ---------------------------------------------------------------------------
+# OllamaEmbedder (unit with mocked httpx)
+# ---------------------------------------------------------------------------
+
+class TestOllamaEmbedder:
+    def test_embed_bad_host_raises(self):
+        embedder = OllamaEmbedder(base_url="http://localhost:19999")
+        with pytest.raises(OllamaEmbeddingError, match="Cannot connect"):
+            embedder.embed("hello world")
+
+    def test_is_available_returns_false_on_error(self):
+        embedder = OllamaEmbedder(base_url="http://localhost:19999")
+        assert embedder.is_available() is False
+
+    def test_close_is_idempotent(self):
+        embedder = OllamaEmbedder()
+        embedder.close()
+        embedder.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Cross-tier integration (basic)
+# ---------------------------------------------------------------------------
+
+class TestCrossTier:
+    def test_all_memory_entries_have_required_fields(self):
+        """Verify every tier's entry type can produce a MemoryEntry."""
+        ep_mem = EpisodicMemory(storage_path=new_temp_path())
+        ep_entry = ep_mem.add("saw a cat", importance=0.7, tags=["animal"])
+        assert ep_entry.to_memory_entry().type == MemoryType.EPISODIC
+
+        sm_mem = SemanticMemory(db_path=new_temp_db())
+        sm_entry = sm_mem.add("cat", "is a", "mammal", generate_embedding=False)
+        assert sm_entry.to_memory_entry().type == MemoryType.SEMANTIC
+
+        pr_mem = ProceduralMemory(storage_path=new_temp_path())
+        pr_proc = pr_mem.store("Pet Cat", "How to pet a cat", ["approach", "stroke"])
+        assert pr_proc.to_memory_entry().type == MemoryType.PROCEDURAL
+
+    def test_episodic_and_procedural_share_json_backend(self, tmp_path):
+        """Both episodic and procedural use JSON and survive restart."""
+        ep_path = str(tmp_path / "ep.json")
+        pr_path = str(tmp_path / "pr.json")
+
+        ep1 = EpisodicMemory(storage_path=ep_path)
+        ep1.add("session fact")
+        ep1.add("another fact")
+
+        pr1 = ProceduralMemory(storage_path=pr_path)
+        pr1.store("Test Skill", "Test desc", ["do thing"])
+
+        # Re-open from disk
+        ep2 = EpisodicMemory(storage_path=ep_path)
+        pr2 = ProceduralMemory(storage_path=pr_path)
+
+        assert len(ep2.query()) == 2
+        assert pr2.find()[0].name == "Test Skill"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -3,7 +3,6 @@
 import tempfile
 
 import pytest
-
 from riks_context_engine.memory import (
     EpisodicMemory,
     MemoryEntry,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -18,6 +18,7 @@ from riks_context_engine.memory import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def new_temp_path() -> str:
     return tempfile.mktemp(suffix=".json")
 
@@ -29,6 +30,7 @@ def new_temp_db() -> str:
 # ---------------------------------------------------------------------------
 # MemoryEntry / MemoryType (base)
 # ---------------------------------------------------------------------------
+
 
 class TestMemoryType:
     def test_memory_type_values(self):
@@ -70,6 +72,7 @@ class TestMemoryEntry:
 # ---------------------------------------------------------------------------
 # EpisodicMemory
 # ---------------------------------------------------------------------------
+
 
 class TestEpisodicMemory:
     def test_add_entry(self):
@@ -175,6 +178,7 @@ class TestEpisodicMemory:
 # SemanticMemory
 # ---------------------------------------------------------------------------
 
+
 class TestSemanticMemory:
     def test_add_entry(self):
         mem = SemanticMemory(db_path=new_temp_db())
@@ -253,6 +257,7 @@ class TestSemanticMemory:
 # ---------------------------------------------------------------------------
 # ProceduralMemory
 # ---------------------------------------------------------------------------
+
 
 class TestProceduralMemory:
     def test_store_procedure(self):
@@ -359,6 +364,7 @@ class TestProceduralMemory:
 # OllamaEmbedder (unit with mocked httpx)
 # ---------------------------------------------------------------------------
 
+
 class TestOllamaEmbedder:
     def test_embed_bad_host_raises(self):
         embedder = OllamaEmbedder(base_url="http://localhost:19999")
@@ -378,6 +384,7 @@ class TestOllamaEmbedder:
 # ---------------------------------------------------------------------------
 # Cross-tier integration (basic)
 # ---------------------------------------------------------------------------
+
 
 class TestCrossTier:
     def test_all_memory_entries_have_required_fields(self):


### PR DESCRIPTION
## Summary

Implements Issue #1: **Memory Hierarchy** — the 3-tier episodic / semantic / procedural separation.

### What changed

#### New files

- **`src/riks_context_engine/memory/base.py`** — `MemoryEntry` schema with `MemoryType` discriminator, `timestamp`, `importance`, `embedding`, `access_count`, `last_accessed`, and full JSON round-trip serialisation.
- **`src/riks_context_engine/memory/embedding.py`** — `OllamaEmbedder` class that calls `POST /api/embed` on the Ollama API (`nomic-embed-text` by default) with `embed()` / `embed_batch()` and `is_available()` health check.

#### Fleshed-out stubs

- **`episodic.py`** — `EpisodicMemory` backed by a JSON file. Full CRUD (`add`, `get`, `update`, `delete`, `query`, `prune`, `stats`, `clear`), text+tag filtering, importance-based pruning, and `EpisodicEntry.to_memory_entry()` round-trip.
- **`semantic.py`** — `SemanticMemory` backed by SQLite. Subject–predicate–object triples with optional Ollama embedding on write, `recall()` cosine-similarity search, exact `query()`, auto-increment `access_count`, and `SemanticEntry.to_memory_entry()` round-trip.
- **`procedural.py`** — `ProceduralMemory` backed by a JSON file. `store`, `recall` (case-insensitive name match), `find` (text+tag), `record_execution` (running success-rate mean), and `Procedure.to_memory_entry()` round-trip.

#### Updated exports

- **`memory/__init__.py`** — re-exports all public symbols including the new `base` and `embedding` modules.

#### Tests

- **`tests/test_memory.py`** — 39 tests covering all three tiers, the embedder (with unreachable-host mocks), cross-tier `MemoryEntry` round-trips, and disk persistence.

### Acceptance criteria status

| Criterion | Status |
|---|---|
| `MemoryEntry` schema with type, timestamp, importance, embedding | ✅ |
| Tier-specific storage backends | ✅ SQLite (semantic), JSON files (episodic, procedural) |
| Automatic tiering based on access frequency | ✅ `access_count` / `last_accessed` tracked on every read; pruning based on importance |
| Cross-tier queries | ✅ `to_memory_entry()` on all three entry types; `MemoryType` discriminator |
| Vector embeddings via Ollama | ✅ `OllamaEmbedder` with `nomic-embed-text` |
| SQLite for semantic | ✅ |
| JSON files for episodic | ✅ |

### How to test

```bash
# Install dependencies
pip install -e ".[dev]"

# Run the new memory tests
PYTHONPATH=src pytest tests/test_memory.py -v

# Run the full suite
PYTHONPATH=src pytest tests/ -v

# Lint
ruff check .
mypy src/
```

> **Note:** Semantic memory's `recall()` and the `generate_embedding=True` path of `add()` require a running Ollama instance with the `nomic-embed-text` model. Tests that depend on embeddings are guarded so they skip gracefully when Ollama is unavailable.