### PR TITLE
test: add staging environment setup and test runner scripts

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,45 @@
+# Environment Configuration for riks-context-engine
+
+# Core
+ENVIRONMENT=staging
+PYTHONPATH=/app
+
+# Data
+DATA_DIR=/app/data
+
+# ChromaDB (embedded, no external DB needed)
+CHROMA_HOST=localhost
+CHROMA_PORT=8000
+
+# Ollama
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_MODEL=gemma4-31b-it
+
+# LLM Provider
+LLM_PROVIDER=ollama  # or openai, anthropic
+
+# OpenAI (if using)
+# OPENAI_API_KEY=sk-...
+
+# Anthropic (if using)
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# Semantic Memory
+SEMANTIC_DB_PATH=/app/data/semantic.db
+
+# Episodic Memory
+EPISODIC_STORAGE_PATH=/app/data/episodic.json
+
+# Procedural Memory
+PROCEDURAL_STORAGE_PATH=/app/data/procedural.json
+
+# Logging
+LOG_LEVEL=DEBUG
+
+# Test/Staging
+TEST_MODE=true
+STAGING_API_URL=http://localhost:8000
+
+# [REPLACE_ME] - Replace with real credentials before use
+# STAGING_DB_URL=postgres://user:password@localhost:5432/staging_db
+# STAGING_REDIS_URL=redis://localhost:6379/0

--- a/docs/TEST_ENVIRONMENT.md
+++ b/docs/TEST_ENVIRONMENT.md
@@ -1,0 +1,113 @@
+# Test Environment — Staging Setup
+
+This document describes the staging/test environment for QA testers.
+
+## Overview
+
+The staging environment is a Docker-based deployment of the riks-context-engine API,
+identical to production in structure but isolated for testing purposes.
+
+**Key differences from development:**
+- `ENVIRONMENT=staging`
+- `TEST_MODE=true`
+- Debug logging enabled
+
+## Starting the Staging Environment
+
+```bash
+# Copy the staging env file
+cp .env.staging.example .env.staging
+
+# Start the staging environment
+docker-compose -f docker-compose.yml --env-file .env.staging up --build -d
+
+# Verify it's running
+docker-compose -f docker-compose.yml ps
+```
+
+## API Endpoints
+
+| Endpoint | Method | Description | Auth |
+|----------|--------|-------------|------|
+| `/` | GET | API health check | None |
+| `/health` | GET | Detailed health status | None |
+| `/context` | POST | Submit a context object | None (local) |
+| `/context/<id>` | GET | Retrieve context by ID | None (local) |
+| `/memory/search` | POST | Semantic memory search | None (local) |
+| `/memory/history` | GET | Episodic memory history | None (local) |
+
+**Base URL:** `http://localhost:8000`
+
+## Test User Credentials
+
+> **Note:** These are local/staging test credentials. No real user data is used.
+
+| Username | Password | Role |
+|----------|----------|------|
+| `test_user` | `test_pass_123` | Read/Write |
+| `test_admin` | `test_admin_456` | Admin |
+
+## Running the Test Suite
+
+```bash
+# Ensure staging is running first
+docker-compose -f docker-compose.yml --env-file .env.staging up --build -d
+
+# Wait for health check
+./scripts/test-staging.sh --wait
+
+# Run the test suite against staging
+pytest tests/ -v --base-url=http://localhost:8000
+
+# Or use the test runner script
+./scripts/test-staging.sh
+```
+
+## Reporting Test Results
+
+After running tests, results are saved to `test-results/`:
+
+```
+test-results/
+├── staging-results.xml   # JUnit XML (CI/CD compatible)
+└── staging-report.html   # HTML report
+```
+
+To attach results to a GitHub issue, use the test runner:
+
+```bash
+./scripts/test-staging.sh --report-issue 16
+```
+
+## Environment Variables
+
+Required variables for staging (see `.env.staging.example`):
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `ENVIRONMENT` | Must be `staging` | `staging` |
+| `TEST_MODE` | Enables test endpoints | `true` |
+| `STAGING_API_URL` | API base URL | `http://localhost:8000` |
+| `OLLAMA_HOST` | Ollama server URL | `http://localhost:11434` |
+| `OLLAMA_MODEL` | Model to use | `gemma4-31b-it` |
+| `LOG_LEVEL` | Logging level | `DEBUG` |
+
+## Troubleshooting
+
+**Container won't start:**
+```bash
+docker-compose logs app
+docker-compose exec app python -c "import src; print('OK')"
+```
+
+**Health check fails:**
+```bash
+curl http://localhost:8000/health
+docker-compose exec app curl http://localhost:8000/health
+```
+
+**Tests timing out:**
+```bash
+# Increase timeout in pytest.ini or run with:
+pytest tests/ -v --timeout=60
+```

--- a/scripts/test-staging.sh
+++ b/scripts/test-staging.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Test runner for staging environment
+# Usage: ./scripts/test-staging.sh [--wait] [--report-issue N]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_DIR"
+
+ENV_FILE=".env.staging"
+RESULTS_DIR="test-results"
+
+start_staging() {
+    echo "==> Starting staging environment..."
+    if [ ! -f "$ENV_FILE" ]; then
+        echo "ERROR: $ENV_FILE not found. Copy from .env.staging.example first."
+        exit 1
+    fi
+    docker-compose -f docker-compose.yml --env-file "$ENV_FILE" up --build -d
+    echo "==> Waiting for staging to be healthy..."
+    wait_health
+}
+
+wait_health() {
+    local max_attempts=30
+    local attempt=1
+    local api_url="${STAGING_API_URL:-http://localhost:8000}"
+
+    while [ $attempt -le $max_attempts ]; do
+        if curl -sf "$api_url/health" > /dev/null 2>&1 || curl -sf "$api_url/" > /dev/null 2>&1; then
+            echo "==> Staging is healthy (attempt $attempt/$max_attempts)"
+            return 0
+        fi
+        echo "    Waiting for health... (attempt $attempt/$max_attempts)"
+        sleep 2
+        attempt=$((attempt + 1))
+    done
+
+    echo "ERROR: Staging failed to become healthy after $max_attempts attempts"
+    docker-compose -f docker-compose.yml logs --tail=20
+    exit 1
+}
+
+run_tests() {
+    echo "==> Running test suite against staging..."
+    mkdir -p "$RESULTS_DIR"
+    pytest tests/ -v --base-url="${STAGING_API_URL:-http://localhost:8000}" \
+        --junitxml="$RESULTS_DIR/staging-results.xml" \
+        --html="$RESULTS_DIR/staging-report.html" --self-contained-html \
+        || true
+    echo "==> Results saved to $RESULTS_DIR/"
+}
+
+teardown() {
+    echo "==> Tearing down staging environment..."
+    docker-compose -f docker-compose.yml --env-file "$ENV_FILE" down || true
+}
+
+report_issue() {
+    local issue_num="$1"
+    echo "==> Reporting results to issue #$issue_num..."
+    if [ -f "$RESULTS_DIR/staging-results.xml" ]; then
+        gh issue comment "$issue_num" --body "## Test Results
+
+Staging tests completed. Results: $RESULTS_DIR/staging-results.xml
+
+To view HTML report: \`cat $RESULTS_DIR/staging-report.html\`" || true
+    else
+        echo "WARNING: No results file found at $RESULTS_DIR/staging-results.xml"
+    fi
+}
+
+show_help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --wait          Wait for health check only"
+    echo "  --report-issue N  Report results to issue N"
+    echo "  --help          Show this help"
+}
+
+main() {
+    case "${1:-}" in
+        --wait)
+            wait_health
+            ;;
+        --report-issue)
+            teardown
+            start_staging
+            run_tests
+            report_issue "${2:-}"
+            ;;
+        --help)
+            show_help
+            ;;
+        *)
+            start_staging
+            run_tests
+            teardown
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## What
Adds a staging/test environment for QA testers with Docker-based deployment and a test runner script.

## Files Added
- **.env.staging.example** — Environment template for staging
- **docs/TEST_ENVIRONMENT.md** — Full staging documentation
- **scripts/test-staging.sh** — One-shot test runner

## How to Test
```bash
cp .env.staging.example .env.staging
./scripts/test-staging.sh
```

## Test Credentials
| Username | Password | Role |
|----------|----------|------|
| test_user | test_pass_123 | Read/Write |
| test_admin | test_admin_456 | Admin |

## API Endpoints
- GET / — health check
- GET /health — detailed health
- POST /context — submit context
- GET /context/<id> — retrieve context
- POST /memory/search — semantic search
- GET /memory/history — episodic history

Base URL: http://localhost:8000