### PR TITLE
fix(docker): add non-root user and bind to localhost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,12 @@ ENV DATA_DIR=/app/data
 ENV ENVIRONMENT=development
 ENV OLLAMA_BASE_URL=http://host.docker.internal:11434
 
+# Create non-root user
+RUN groupadd -r appgroup && useradd -r -g appgroup appuser
+
+# Switch to non-root user
+USER appuser
+
 # Expose default port
 EXPOSE 8000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ./data:/app/data
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     networks:
       - riks-dev
     healthcheck:


### PR DESCRIPTION
## Changes

- **Dockerfile:** Added non-root user (appgroup/appuser) with USER directive
- **docker-compose.yml:** Port bound to 127.0.0.1 instead of all interfaces

## Security Fixes

- Closes #31 (container running as root)
- Closes #30 (port exposed on all interfaces)

## Testing

- `docker-compose up --build`
- `curl http://127.0.0.1:8000/health`
- `docker inspect riks-sandbox | grep User`

## Notes

- Build test: PASS
- Compose validate: PASS (version field obsolete warning only)
- Healthcheck curl dependency satisfied by base image