### PR TITLE
fix(#57): OllamaEmbedder connection reuse — httpx connection pooling

### DIFF
--- a/src/riks_context_engine/memory/embedding.py
+++ b/src/riks_context_engine/memory/embedding.py
@@ -42,7 +42,15 @@ class OllamaEmbedder:
     @property
     def client(self) -> httpx.Client:
         if self._client is None:
-            self._client = httpx.Client(base_url=self.base_url, timeout=self.timeout)
+            self._client = httpx.Client(
+                base_url=self.base_url,
+                timeout=self.timeout,
+                limits=httpx.Limits(
+                    max_keepalive_connections=20,
+                    max_connections=100,
+                    keepalive_expiry=120.0,
+                ),
+            )
         return self._client
 
     def embed(self, text: str) -> EmbeddingResult:

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -13,6 +13,23 @@ from riks_context_engine.memory.embedding import (
 class TestOllamaEmbedder:
     """Tests for OllamaEmbedder and get_embedder."""
 
+    def test_client_uses_connection_pool(self):
+        """Client should be configured with connection pooling limits."""
+        embedder = OllamaEmbedder()
+        # Verify the client was created (not None)
+        assert embedder.client is not None
+        # The client limits are configured on init; we verify the client works
+        # Connection reuse happens automatically with keepalive connections
+        embedder.close()
+
+    def test_client_is_cached(self):
+        """client property should return the same instance on repeated access."""
+        embedder = OllamaEmbedder()
+        c1 = embedder.client
+        c2 = embedder.client
+        assert c1 is c2
+        embedder.close()
+
     def test_get_embedder_returns_embedder(self):
         """get_embedder should return an OllamaEmbedder object."""
         embedder = get_embedder()


### PR DESCRIPTION
## Summary

Adds httpx connection pooling to `OllamaEmbedder.client` for better connection reuse under load (issue #57).

### What was changed

**`src/riks_context_engine/memory/embedding.py`**
- `client` property now configures `httpx.Limits` on the `httpx.Client`:
  - `max_keepalive_connections=20` — reuse connections across calls
  - `max_connections=100` — concurrency cap
  - `keepalive_expiry=120.0s` — connection TTL before cleanup

The client was already cached (singleton per `OllamaEmbedder` instance);
this change adds connection pooling limits on top for stability under load.

**`tests/test_embedding.py`**
- `test_client_uses_connection_pool` — verifies client is properly initialized
- `test_client_is_cached` — verifies same client instance is returned

### Test results
- 276 tests pass (test_embedding.py: 14/14)
- mypy clean, ruff clean