### PR TITLE
docs(changelog): update CHANGELOG for v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2026-05-31
 
 ### Added
+- **`feat(context)`: Coherence validation** — `validate_coherence()` and `get_coherence_score()` methods for measuring and validating context window coherence ([#85](https://github.com/vopsiton/riks-context-engine/pull/85))
 - **`feat(memory)`: JSON/YAML export/import** — Full memory portability across models and sessions ([#36](https://github.com/vopsiton/riks-context-engine/issues/36))
   - `export_memory()` — selective export by type, date range, and tags
   - `dump_manifest()` / `parse_manifest()` — JSON and YAML serialization
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`fix(kg)`**: Explicit `strict=True` in `zip()` in `_cosine_similarity` (Ruff B905 — prevents silent truncation on mismatched vector lengths)
+- **`fix`: Multiple production bugs** — Various bug fixes discovered during test runs ([#82](https://github.com/vopsiton/riks-context-engine/pull/82))
 
 ### Dependencies
 - Added `pyyaml>=6.0`


### PR DESCRIPTION
Document what changed in v0.2.1, including the validate_coherence methods added in the latest commit, and confirm all recent PRs (#82, #83, #84, #85) are reflected.

## Changes

- **PR #85** — Added `validate_coherence()` and `get_coherence_score()` methods to the context module
- **PR #82** — Fixed multiple production bugs discovered during test runs
- **PR #83** — No such PR exists (skipped)
- **PR #84** — ROADMAP.md addition (docs-only, not a code feature — not included in CHANGELOG)

## Notes

- PR #85's `validate_coherence` and `get_coherence_score` methods were not explicitly documented in the original v0.2.1 entry
- PR #82's production bug fixes were also missing from the changelog
- PR #83 does not exist in the repository