### PR TITLE
fix(version): align __version__ in __init__.py to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.1] - 2026-05-31
 
+### Fixed
+- **`fix(version)`: `__version__` alignment** — `__init__.py` declared `0.1.0` but `pyproject.toml` declared `0.2.0`. Updated `__version__` to `0.2.0` for consistency across package and CLI ([opsiton-team#cron-2026-05-31])
+
 ### Added
 - **`feat(context)`: Coherence validation** — `validate_coherence()` and `get_coherence_score()` methods for measuring and validating context window coherence ([#85](https://github.com/vopsiton/riks-context-engine/pull/85))
 - **`feat(memory)`: JSON/YAML export/import** — Full memory portability across models and sessions ([#36](https://github.com/vopsiton/riks-context-engine/issues/36))

--- a/src/riks_context_engine/__init__.py
+++ b/src/riks_context_engine/__init__.py
@@ -1,3 +1,3 @@
 """Rik's Context Engine - AI context and memory management framework."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
## Summary
Fixed __version__ mismatch between __init__.py (0.1.0) and pyproject.toml (0.2.0). The CLI and package were reporting different versions.

## Changes
- src/riks_context_engine/__init__.py: Updated __version__ from 0.1.0 to 0.2.0
- CHANGELOG.md: Added fix entry under 0.2.1 unreleased section

## How to test
1. python -c 'from riks_context_engine import __version__; print(__version__)' → should print 0.2.0
2. riks --version → should print riks-context-engine 0.2.0
3. Verify riks version matches pyproject.toml version

## Checklist
- [x] Version numbers consistent across package
- [x] CHANGELOG updated
- [x] No breaking changes