### PR TITLE
docs: v0.3.0 release — CHANGELOG, README, ROADMAP consistency fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to **Rik Context Engine** will be documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-31
+
+### Added
+- **`feat(context)`: Semantic Summarization** — LLM-generated compression of TIER_3 messages to ≤20% token count while preserving key facts, decisions, and intent ([#86](https://github.com/vopsiton/riks-context-engine/issues/86))
+  - `SemanticSummarizer` class with `summarize_tier3()`, `SummarizedBlock` dataclass
+  - Keyword-extraction fallback when LLM unavailable
+  - `set_summarizer()` / `run_summarization()` integrated into `ContextWindowManager`
+- **`feat(context)`: Priority Inheritance** — Child messages inherit parent importance; thread coherence scoring via `get_thread_coherence()` ([#94](https://github.com/vopsiton/riks-context-engine/issues/94))
+- **`docs`: PR Template & Code Review Checklist** — Enforced PR description format with logic/style/security/testing checklist ([#92](https://github.com/vopsiton/riks-context-engine/issues/92))
+
+---
+
 ## [0.2.1] - 2026-05-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ pre-commit run --all-files
 
 | Metric | Status |
 |--------|--------|
-| **Version** | v1.0.0 |
+| **Version** | v0.3.0 |
 | **All Issues** | ✅ CLOSED (11/11) |
 | **All PRs** | ✅ MERGED (5/5) |
 | **UAT** | ✅ 484 PASS, 71 SKIP, 0 FAIL |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,4 +105,4 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and PR guidelines
 
 ---
 
-*Last updated: 2026-05-31 — v0.2.1 production release*
+*Last updated: 2026-05-31 — v0.3.0 production release*


### PR DESCRIPTION
## Summary

Fixes version inconsistency across documentation files after v0.3.0 features were merged.

### Problem
| File | Was | Should Be |
|------|-----|-----------|
| `CHANGELOG.md` | Missing v0.3.0 entry | Add entry for semantic summarization, priority inheritance, PR template |
| `README.md` | v1.0.0 | v0.3.0 (authoritative source: CHANGELOG) |
| `ROADMAP.md` | v0.2.1 production release | v0.3.0 production release |

### Changes
- **`CHANGELOG.md`**: Added `[0.3.0] - 2026-05-31` entry documenting:
  - `feat(context)`: Semantic Summarization (#86) — TIER_3 compression to ≤20% token count
  - `feat(context)`: Priority Inheritance (#94) — child message importance inheritance
  - `docs`: PR Template & Code Review Checklist (#92)
- **`README.md`**: Version `v1.0.0` → `v0.3.0`
- **`ROADMAP.md`**: Updated last-updated note to v0.3.0

### Testing
- No functional changes — documentation only
- `git diff --stat`: 3 files, 14 insertions, 2 deletions

## Checklist
- [x] CHANGELOG follows [Keep a Changelog](https://keepachangelog.com/) format
- [x] Conventional commit message
- [x] No functional code changes
- [x] PR description filled (template not auto-applied on this branch)

---
_Generated by opsiton-lead agent (Rik) — 2026-05-31_