### PR TITLE
feat(memory): PostgreSQL-backed semantic memory store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,19 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rce_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +47,8 @@ jobs:
         run: mypy src/
 
       - name: Run tests
+        env:
+          TEST_POSTGRES_DSN: postgresql://postgres:postgres@localhost:5432/rce_test
         run: pytest --cov=src/ --cov-report=xml
 
       - name: Upload coverage

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ src/riks_context_engine/
 │   ├── base.py              # MemoryEntry schema (unified 3-tier format)
 │   ├── episodic.py          # EpisodicMemory — session-level JSON store
 │   ├── semantic.py          # SemanticMemory — SQLite + ChromaDB
+│   ├── postgres.py          # PostgresSemanticMemory — optional PostgreSQL backend
 │   ├── procedural.py        # ProceduralMemory — skills & workflows
 │   └── embedding.py         # Ollama embedder integration
 ├── context/
@@ -178,6 +179,14 @@ src/riks_context_engine/
 | Procedural | JSON file (`data/procedural.json`) | Human-readable, easy to edit |
 | Knowledge Graph | SQLite (`data/knowledge_graph.db`) | Graph queries with foreign keys |
 | Context Window | In-memory | Transient, not persisted |
+
+Semantic memory also has an optional PostgreSQL backend
+(`PostgresSemanticMemory`) for deployments that need a shared, multi-process,
+or horizontally-scaled store instead of a local SQLite file. Install with the
+`postgres` extra (`pip install riks-context-engine[postgres]`) and apply the
+schema with `POSTGRES_DSN=... python scripts/migrate_postgres.py`. It exposes
+the same `add`/`get`/`query`/`recall`/`delete` interface as `SemanticMemory`,
+so it's a drop-in swap.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,11 @@ dev = [
     "ruff>=0.9",
     "mypy>=1.5",
     "pre-commit>=3.3",
+    "psycopg[binary]>=3.1",
 ]
 openai = ["openai>=1.0"]
 anthropic = ["anthropic>=0.18"]
+postgres = ["psycopg[binary]>=3.1"]
 
 [project.scripts]
 riks = "riks_context_engine.cli.main:main"

--- a/scripts/migrate_postgres.py
+++ b/scripts/migrate_postgres.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Apply pending PostgreSQL migrations for riks-context-engine.
+
+Usage:
+    POSTGRES_DSN=postgresql://user:pass@host:5432/dbname python scripts/migrate_postgres.py
+
+Migration files live in scripts/migrations/*.sql and are applied in
+lexical order. Applied filenames are tracked in a schema_migrations
+table, so re-running the script is a no-op once everything is applied.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import psycopg
+
+MIGRATIONS_DIR = Path(__file__).parent / "migrations"
+
+
+def main() -> int:
+    dsn = os.environ.get("POSTGRES_DSN")
+    if not dsn:
+        print("POSTGRES_DSN environment variable is required", file=sys.stderr)
+        return 1
+
+    migrations = sorted(MIGRATIONS_DIR.glob("*.sql"))
+    if not migrations:
+        print("No migration files found in scripts/migrations/")
+        return 0
+
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_migrations (
+                    filename TEXT PRIMARY KEY,
+                    applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+                """
+            )
+            cur.execute("SELECT filename FROM schema_migrations")
+            applied = {row[0] for row in cur.fetchall()}
+
+        for migration in migrations:
+            if migration.name in applied:
+                print(f"skip  {migration.name} (already applied)")
+                continue
+            with conn.cursor() as cur:
+                cur.execute(migration.read_text())
+                cur.execute(
+                    "INSERT INTO schema_migrations (filename) VALUES (%s)",
+                    (migration.name,),
+                )
+            print(f"apply {migration.name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrations/0001_create_semantic_entries.sql
+++ b/scripts/migrations/0001_create_semantic_entries.sql
@@ -1,0 +1,17 @@
+-- Creates the semantic_entries table used by PostgresSemanticMemory
+-- (src/riks_context_engine/memory/postgres.py).
+
+CREATE TABLE IF NOT EXISTS semantic_entries (
+    id TEXT PRIMARY KEY,
+    subject TEXT NOT NULL,
+    predicate TEXT NOT NULL,
+    object TEXT,
+    confidence DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    created_at TIMESTAMPTZ NOT NULL,
+    last_accessed TIMESTAMPTZ NOT NULL,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    embedding JSONB
+);
+
+CREATE INDEX IF NOT EXISTS idx_semantic_subject ON semantic_entries(subject);
+CREATE INDEX IF NOT EXISTS idx_semantic_predicate ON semantic_entries(predicate);

--- a/src/riks_context_engine/memory/postgres.py
+++ b/src/riks_context_engine/memory/postgres.py
@@ -1,0 +1,215 @@
+"""PostgreSQL-backed semantic memory store (optional backend).
+
+Drop-in replacement for :class:`~riks_context_engine.memory.semantic.SemanticMemory`
+when a shared, multi-process, or horizontally-scaled store is needed instead
+of a local SQLite file. Requires the ``postgres`` extra::
+
+    pip install riks-context-engine[postgres]
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from riks_context_engine.memory.semantic import SemanticEntry
+
+if TYPE_CHECKING:
+    from riks_context_engine.memory.base import MemoryEntry
+
+try:
+    import psycopg
+    from psycopg.rows import dict_row
+    from psycopg.types.json import Jsonb
+except ImportError as exc:  # pragma: no cover - exercised only without the extra
+    raise ImportError(
+        "PostgresSemanticMemory requires the 'postgres' extra: "
+        "pip install riks-context-engine[postgres]"
+    ) from exc
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS semantic_entries (
+    id TEXT PRIMARY KEY,
+    subject TEXT NOT NULL,
+    predicate TEXT NOT NULL,
+    object TEXT,
+    confidence DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    created_at TIMESTAMPTZ NOT NULL,
+    last_accessed TIMESTAMPTZ NOT NULL,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    embedding JSONB
+)
+"""
+_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_semantic_subject ON semantic_entries(subject)",
+    "CREATE INDEX IF NOT EXISTS idx_semantic_predicate ON semantic_entries(predicate)",
+)
+
+
+class PostgresSemanticMemory:
+    """Long-term structured knowledge store backed by PostgreSQL.
+
+    Mirrors the public interface of
+    :class:`~riks_context_engine.memory.semantic.SemanticMemory` (``add``,
+    ``get``, ``query``, ``recall``, ``delete``, ``__len__``) so the two are
+    interchangeable wherever a semantic memory store is expected.
+    """
+
+    def __init__(self, dsn: str, embedder: Any = None):
+        self.dsn = dsn
+        self.embedder = embedder
+        self._conn = psycopg.connect(dsn, autocommit=True, row_factory=dict_row)
+        self._init_db()
+
+    def __del__(self):
+        conn = getattr(self, "_conn", None)
+        if conn is not None and not conn.closed:
+            conn.close()
+
+    def _init_db(self) -> None:
+        """Initialize the PostgreSQL schema."""
+        with self._conn.cursor() as cur:
+            cur.execute(_SCHEMA)
+            for stmt in _INDEXES:
+                cur.execute(stmt)
+
+    def add(
+        self,
+        subject: str,
+        predicate: str,
+        object: str | None = None,
+        confidence: float = 1.0,
+        embedding: list[float] | None = None,
+    ) -> SemanticEntry:
+        """Add a semantic knowledge entry."""
+        now = datetime.now(timezone.utc)
+        entry = SemanticEntry(
+            id=f"sm_{now.timestamp()}",
+            subject=subject,
+            predicate=predicate,
+            object=object,
+            confidence=confidence,
+            created_at=now,
+            last_accessed=now,
+            embedding=embedding,
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO semantic_entries
+                (id, subject, predicate, object, confidence, created_at, last_accessed, access_count, embedding)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    entry.id,
+                    entry.subject,
+                    entry.predicate,
+                    entry.object,
+                    entry.confidence,
+                    entry.created_at,
+                    entry.last_accessed,
+                    entry.access_count,
+                    Jsonb(embedding) if embedding else None,
+                ),
+            )
+        return entry
+
+    def get(self, entry_id: str) -> SemanticEntry | None:
+        """Get entry by ID, incrementing access count."""
+        with self._conn.cursor() as cur:
+            cur.execute("SELECT * FROM semantic_entries WHERE id = %s", (entry_id,))
+            row = cur.fetchone()
+        if not row:
+            return None
+        entry = self._row_to_entry(row)
+        entry.access_count += 1
+        entry.last_accessed = datetime.now(timezone.utc)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE semantic_entries SET access_count = %s, last_accessed = %s WHERE id = %s",
+                (entry.access_count, entry.last_accessed, entry_id),
+            )
+        return entry
+
+    def _row_to_entry(self, row: dict[str, Any]) -> SemanticEntry:
+        # psycopg deserializes JSONB columns to Python objects automatically,
+        # unlike the sqlite3 backend which stores embeddings as raw JSON text.
+        return SemanticEntry(
+            id=row["id"],
+            subject=row["subject"],
+            predicate=row["predicate"],
+            object=row["object"],
+            confidence=row["confidence"],
+            created_at=row["created_at"],
+            last_accessed=row["last_accessed"],
+            access_count=row["access_count"],
+            embedding=row["embedding"],
+        )
+
+    def query(
+        self, subject: str | None = None, predicate: str | None = None
+    ) -> list[SemanticEntry]:
+        """Query semantic memory by subject and/or predicate."""
+
+        def _escape(s: str) -> str:
+            return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+        conditions = []
+        params: list[str] = []
+        if subject:
+            conditions.append("subject ILIKE %s ESCAPE '\\'")
+            params.append(f"%{_escape(subject)}%")
+        if predicate:
+            conditions.append("predicate ILIKE %s ESCAPE '\\'")
+            params.append(f"%{_escape(predicate)}%")
+
+        sql = "SELECT * FROM semantic_entries"
+        if conditions:
+            sql += " WHERE " + " AND ".join(conditions)
+
+        with self._conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return [self._row_to_entry(r) for r in rows]
+
+    def recall(self, query: str) -> list[SemanticEntry]:
+        """Semantic search across knowledge using keyword matching."""
+        q = query.lower()
+        with self._conn.cursor() as cur:
+            cur.execute("SELECT * FROM semantic_entries")
+            rows = cur.fetchall()
+        matches = []
+        for row in rows:
+            entry = self._row_to_entry(row)
+            if (
+                q in entry.subject.lower()
+                or q in entry.predicate.lower()
+                or (entry.object and q in entry.object.lower())
+            ):
+                matches.append(entry)
+        return matches
+
+    def to_memory_entry(self, entry: SemanticEntry) -> MemoryEntry:
+        """Convert a :class:`SemanticEntry` to the generic :class:`MemoryEntry` schema."""
+        from riks_context_engine.memory.base import MemoryEntry, MemoryType
+
+        return MemoryEntry(
+            id=entry.id,
+            type=MemoryType.SEMANTIC,
+            content=f"{entry.subject} {entry.predicate} {entry.object or ''}",
+            importance=entry.confidence,
+            embedding=entry.embedding,
+            access_count=entry.access_count,
+            last_accessed=entry.last_accessed,
+        )
+
+    def __len__(self) -> int:
+        with self._conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) AS count FROM semantic_entries")
+            row = cur.fetchone()
+        return row["count"] if row else 0
+
+    def delete(self, entry_id: str) -> bool:
+        with self._conn.cursor() as cur:
+            cur.execute("DELETE FROM semantic_entries WHERE id = %s", (entry_id,))
+            return cur.rowcount > 0

--- a/tests/test_memory_postgres.py
+++ b/tests/test_memory_postgres.py
@@ -1,0 +1,134 @@
+"""Tests for the PostgreSQL-backed semantic memory store.
+
+Requires a reachable PostgreSQL instance via TEST_POSTGRES_DSN. Skipped
+automatically when that isn't set (e.g. no local Postgres) or when the
+`postgres` extra isn't installed. CI provides a postgres service
+container and sets TEST_POSTGRES_DSN so these run for real there.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+psycopg = pytest.importorskip("psycopg")
+
+from riks_context_engine.memory.postgres import PostgresSemanticMemory  # noqa: E402
+
+DSN = os.environ.get("TEST_POSTGRES_DSN")
+
+pytestmark = pytest.mark.skipif(
+    not DSN, reason="TEST_POSTGRES_DSN not set; skipping PostgreSQL integration tests"
+)
+
+
+@pytest.fixture
+def mem():
+    store = PostgresSemanticMemory(dsn=DSN)
+    yield store
+    with store._conn.cursor() as cur:
+        cur.execute("DELETE FROM semantic_entries")
+
+
+class TestPostgresSemanticMemory:
+    def test_add_entry(self, mem):
+        entry = mem.add(subject="Rik", predicate="is", object="an AI assistant", confidence=0.95)
+        assert entry.subject == "Rik"
+        assert entry.predicate == "is"
+        assert entry.confidence == 0.95
+
+    def test_get_increments_access_count(self, mem):
+        entry = mem.add("Vahit", "works at", "opsiton")
+        assert entry.access_count == 0
+
+        fetched = mem.get(entry.id)
+        assert fetched is not None
+        assert fetched.access_count == 1
+        assert fetched.last_accessed is not None
+
+    def test_get_returns_none_for_missing(self, mem):
+        assert mem.get("nonexistent") is None
+
+    def test_query_by_subject(self, mem):
+        mem.add("auth_service", "uses", "JWT")
+        mem.add("billing_service", "uses", "Stripe")
+
+        results = mem.query(subject="auth")
+        assert len(results) == 1
+        assert results[0].subject == "auth_service"
+
+    def test_query_by_predicate(self, mem):
+        mem.add("auth_service", "uses", "JWT")
+        mem.add("billing_service", "depends_on", "auth_service")
+
+        results = mem.query(predicate="uses")
+        assert len(results) == 1
+        assert results[0].predicate == "uses"
+
+    def test_query_by_subject_and_predicate(self, mem):
+        mem.add("auth_service", "uses", "JWT")
+        mem.add("auth_service", "owned_by", "platform_team")
+
+        results = mem.query(subject="auth", predicate="uses")
+        assert len(results) == 1
+        assert results[0].object == "JWT"
+
+    def test_query_returns_all_when_no_filters(self, mem):
+        mem.add("a", "b", "c")
+        mem.add("d", "e", "f")
+
+        assert len(mem.query()) == 2
+
+    def test_query_escapes_like_wildcards(self, mem):
+        mem.add("100%_done", "status", "complete")
+        mem.add("other", "status", "pending")
+
+        results = mem.query(subject="100%_done")
+        assert len(results) == 1
+        assert results[0].subject == "100%_done"
+
+    def test_recall_keyword_match(self, mem):
+        mem.add("Rik", "is", "an AI assistant")
+        mem.add("Vahit", "works at", "opsiton")
+
+        results = mem.recall("opsiton")
+        assert len(results) == 1
+        assert results[0].subject == "Vahit"
+
+    def test_recall_no_match_returns_empty(self, mem):
+        mem.add("Rik", "is", "an AI assistant")
+        assert mem.recall("xyzzy_not_found") == []
+
+    def test_embedding_round_trip(self, mem):
+        entry = mem.add("x", "y", "z", embedding=[0.1, 0.2, 0.3])
+        fetched = mem.get(entry.id)
+        assert fetched is not None
+        assert fetched.embedding == [0.1, 0.2, 0.3]
+
+    def test_delete_returns_true_and_removes(self, mem):
+        entry = mem.add("temp", "fact", "value")
+        assert len(mem) == 1
+
+        assert mem.delete(entry.id) is True
+        assert len(mem) == 0
+
+    def test_delete_returns_false_for_missing(self, mem):
+        assert mem.delete("nonexistent") is False
+
+    def test_len(self, mem):
+        assert len(mem) == 0
+        mem.add("a", "b", "c")
+        assert len(mem) == 1
+        mem.add("d", "e", "f")
+        assert len(mem) == 2
+
+    def test_to_memory_entry(self, mem):
+        from riks_context_engine.memory.base import MemoryType
+
+        entry = mem.add("auth_service", "uses", "JWT RS256", confidence=0.9)
+        generic = mem.to_memory_entry(entry)
+
+        assert generic.type == MemoryType.SEMANTIC
+        assert generic.content == "auth_service uses JWT RS256"
+        assert generic.importance == 0.9


### PR DESCRIPTION
## Summary
- Adds `PostgresSemanticMemory` (`src/riks_context_engine/memory/postgres.py`) as an optional drop-in alternative to the SQLite-backed `SemanticMemory`, for deployments that need a shared/multi-process/horizontally-scaled context store.
- Same public interface as `SemanticMemory` (`add`, `get`, `query`, `recall`, `delete`, `__len__`), so it's a swap-in — no other code needs to change to use it.
- New `postgres` extra (`pip install riks-context-engine[postgres]`) keeps `psycopg` optional; it's also added to `dev` so CI can exercise it.
- Migration tooling: `scripts/migrate_postgres.py` applies `scripts/migrations/*.sql` in order and tracks applied files in a `schema_migrations` table (idempotent re-runs).
- Integration tests in `tests/test_memory_postgres.py`, gated on `TEST_POSTGRES_DSN` (skipped without it). CI now spins up a `postgres:16-alpine` service container in `ci.yml` and sets `TEST_POSTGRES_DSN` so these run for real in CI, not just locally.
- README: documents the new backend under "Storage Backends".

Closes #104.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` pass on the new files
- [x] `pytest tests/test_memory_postgres.py` — 15/15 passing against a local `postgres:16-alpine` container
- [x] `scripts/migrate_postgres.py` run twice against a live DB — applies once, then reports already-applied (idempotent)
- [x] Full suite run locally with `TEST_POSTGRES_DSN` set — 394 passed, 98 skipped, 5 pre-existing failures unrelated to this change (confirmed present on `master` before this branch: `tests/test_export.py` schema-version validation tests and `tests/test_priority_inheritance.py::test_tier0_not_inherited`)