### PR TITLE
feat(multi-tenant): tenant isolation for context queries + header validation

### DIFF
--- a/src/riks_context_engine/api/server.py
+++ b/src/riks_context_engine/api/server.py
@@ -31,6 +31,12 @@ from riks_context_engine.memory.export import (
 )
 from riks_context_engine.memory.procedural import ProceduralMemory
 from riks_context_engine.memory.semantic import SemanticMemory
+from riks_context_engine.multi_tenant import (
+    TENANT_HEADER,
+    TenantContextRegistry,
+    TenantValidationError,
+    validate_tenant_id,
+)
 
 
 class ChatRequest(BaseModel):
@@ -50,7 +56,15 @@ API_KEY = os.environ.get("API_KEY", "")
 # ─── API Key Middleware ────────────────────────────────────────────────────────
 
 _API_KEY_PROTECTED_PATHS = frozenset(
-    ["/", "/api/chat", "/api/v1/memory/export", "/api/v1/memory/import", "/models"]
+    [
+        "/",
+        "/api/chat",
+        "/api/v1/memory/export",
+        "/api/v1/memory/import",
+        "/models",
+        "/api/v1/context/messages",
+        "/api/v1/context/summary",
+    ]
 )
 
 
@@ -61,6 +75,30 @@ class APIKeyAuthMiddleware(BaseHTTPMiddleware):
         if request.url.path in _API_KEY_PROTECTED_PATHS and API_KEY:
             if request.headers.get("X-API-Key") != API_KEY:
                 return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
+        return await call_next(request)
+
+
+# ─── Tenant Isolation (closes part of #102) ──────────────────────────────────
+
+
+class TenantAuthMiddleware(BaseHTTPMiddleware):
+    """Validate the X-Tenant-Id header on protected paths (#102).
+
+    Consistent contract (all tenant-validation failures -> 401):
+    - header missing -> 401
+    - header empty/whitespace -> 401
+    - header malformed (bad chars / >64 chars) -> 401
+
+    The validated id is stored on ``request.state.tenant_id`` for
+    downstream handlers.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path in _API_KEY_PROTECTED_PATHS:
+            try:
+                request.state.tenant_id = validate_tenant_id(request.headers.get(TENANT_HEADER))
+            except TenantValidationError as exc:
+                return JSONResponse(status_code=401, content={"detail": exc.detail})
         return await call_next(request)
 
 
@@ -162,6 +200,10 @@ def _set_context_manager(mgr: ContextWindowManager | None) -> None:
 def _get_context_manager() -> ContextWindowManager | None:  # noqa: F821
     """Get the module-level context manager."""
     return _context_manager
+
+
+# Module-level tenant-scoped context registry (#102)
+_tenant_registry = TenantContextRegistry()
 
 
 # ─── WebSocket Context Streaming ───────────────────────────────────────────────
@@ -530,6 +572,8 @@ app.add_middleware(
 
 app.add_middleware(RateLimitMiddleware)
 app.add_middleware(APIKeyAuthMiddleware)
+# Tenant isolation MUST run after API-key auth: auth first, then scope.
+app.add_middleware(TenantAuthMiddleware)
 
 # Register WebSocket endpoint (after app is defined)
 app.add_api_websocket_route("/ws/v1/context/stream", websocket_context_stream)
@@ -562,6 +606,62 @@ def chat(req: ChatRequest) -> ChatResponse:
 def root() -> FileResponse:
     ui_path = os.environ.get("UI_PATH", "ui/index.html")
     return FileResponse(ui_path)
+
+
+# ─── Context Endpoints (tenant-scoped, #102) ──────────────────────────────────
+
+
+class ContextAddRequest(BaseModel):
+    role: str = Field("user", description="user | assistant | system")
+    content: str = Field(..., description="Message content")
+    importance: float = Field(0.5, ge=0.0, le=1.0)
+
+
+@app.post("/api/v1/context/messages")
+def context_add_message(req: ContextAddRequest, request: Request) -> dict[str, Any]:
+    """Append a message to the caller's tenant context window."""
+    tenant_id: str = request.state.tenant_id  # set by TenantAuthMiddleware
+    if req.role not in ("user", "assistant", "system"):
+        raise HTTPException(status_code=400, detail="Invalid role")
+    msg = _tenant_registry.get(tenant_id).add(
+        role=req.role, content=req.content, importance=req.importance
+    )
+    return {"message_id": msg.id, "role": msg.role, "tokens": msg.tokens, "status": "added"}
+
+
+@app.get("/api/v1/context/messages")
+def context_list_messages(request: Request) -> list[dict[str, Any]]:
+    """List the caller's tenant context window. Isolated per tenant."""
+    tenant_id: str = request.state.tenant_id
+    msgs = _tenant_registry.get(tenant_id).get_messages(include_pruned=False)
+    return [
+        {
+            "id": m.id,
+            "role": m.role,
+            "content": m.content,
+            "timestamp": m.timestamp.isoformat(),
+            "importance": m.importance,
+            "tokens": m.tokens,
+        }
+        for m in msgs
+    ]
+
+
+@app.get("/api/v1/context/summary")
+def context_summary(request: Request) -> dict[str, Any]:
+    """Context window stats for the caller's tenant only."""
+    tenant_id: str = request.state.tenant_id
+    stats = _tenant_registry.get(tenant_id).stats
+    return {
+        "current_tokens": stats.current_tokens,
+        "max_tokens": stats.max_tokens,
+        "messages_count": stats.messages_count,
+        "active_messages_count": stats.active_messages_count,
+        "pruning_count": stats.pruning_count,
+        "last_prune_timestamp": (
+            stats.last_prune_timestamp.isoformat() if stats.last_prune_timestamp else None
+        ),
+    }
 
 
 # ─── Memory Export/Import Endpoints ───────────────────────────────────────────

--- a/src/riks_context_engine/mcp/handlers.py
+++ b/src/riks_context_engine/mcp/handlers.py
@@ -7,8 +7,13 @@ from typing import Any
 
 from ..context.manager import ContextWindowManager
 from ..memory import EpisodicMemory, ProceduralMemory, SemanticMemory
+from ..multi_tenant import TenantContextRegistry, TenantValidationError, validate_tenant_id
 
 logger = logging.getLogger(__name__)
+
+
+class TenantIsolationError(Exception):
+    """Raised when a tool call fails tenant validation/isolation."""
 
 
 class ToolHandler:
@@ -21,12 +26,14 @@ class ToolHandler:
         procedural_memory: ProceduralMemory | None = None,
         context_manager: ContextWindowManager | None = None,
         data_dir: str | None = None,
+        tenant_registry: TenantContextRegistry | None = None,
     ):
         self.data_dir = data_dir or "data"
         self._episodic = episodic_memory
         self._semantic = semantic_memory
         self._procedural = procedural_memory
         self._context = context_manager
+        self._tenant_registry = tenant_registry or TenantContextRegistry()
 
     # -- Lazy initialisers ---------------------------------------------------
 
@@ -195,14 +202,19 @@ class ToolHandler:
         return {"json": json.dumps(export_data, indent=2, default=str)}
 
     def context_add_message(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Add a message to the context window."""
+        """Add a message to the caller's tenant context window (#102)."""
+        try:
+            tenant_id = validate_tenant_id(params.get("tenant_id"))
+        except TenantValidationError as exc:
+            raise TenantIsolationError(str(exc)) from exc
         role = params.get("role", "user")
         content = params.get("content", "")
         importance = params.get("importance", 0.5)
         is_grounding = params.get("is_grounding", False)
 
         try:
-            msg = self._get_context().add(
+            # Per-tenant manager: structural isolation (A can't see B).
+            msg = self._tenant_registry.get(tenant_id).add(
                 role=role,
                 content=content,
                 importance=importance,
@@ -219,9 +231,12 @@ class ToolHandler:
             raise
 
     def context_get_summary(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Get context window statistics."""
-        del params
-        ctx = self._get_context()
+        """Get the caller's tenant context window statistics (#102)."""
+        try:
+            tenant_id = validate_tenant_id(params.get("tenant_id"))
+        except TenantValidationError as exc:
+            raise TenantIsolationError(str(exc)) from exc
+        ctx = self._tenant_registry.get(tenant_id)
         stats = ctx.stats
         return {
             "current_tokens": stats.current_tokens,

--- a/src/riks_context_engine/mcp/schemas.py
+++ b/src/riks_context_engine/mcp/schemas.py
@@ -98,10 +98,14 @@ TOOL_SCHEMAS = {
     },
     "context_add_message": {
         "name": "context_add_message",
-        "description": "Add a message to the active context window.",
+        "description": "Add a message to the tenant's context window.",
         "inputSchema": {
             "type": "object",
             "properties": {
+                "tenant_id": {
+                    "type": "string",
+                    "description": "Tenant id (X-Tenant-Id); required for isolation (#102)",
+                },
                 "role": {
                     "type": "string",
                     "enum": ["user", "assistant", "system"],
@@ -124,15 +128,21 @@ TOOL_SCHEMAS = {
                     "default": False,
                 },
             },
-            "required": ["role", "content"],
+            "required": ["tenant_id", "role", "content"],
         },
     },
     "context_get_summary": {
         "name": "context_get_summary",
-        "description": "Get current context window statistics and token usage.",
+        "description": "Get the tenant's context window statistics and token usage.",
         "inputSchema": {
             "type": "object",
-            "properties": {},
+            "properties": {
+                "tenant_id": {
+                    "type": "string",
+                    "description": "Tenant id (X-Tenant-Id); required for isolation (#102)",
+                },
+            },
+            "required": ["tenant_id"],
         },
     },
     "health_check": {

--- a/src/riks_context_engine/memory/postgres.py
+++ b/src/riks_context_engine/memory/postgres.py
@@ -212,4 +212,5 @@ class PostgresSemanticMemory:
     def delete(self, entry_id: str) -> bool:
         with self._conn.cursor() as cur:
             cur.execute("DELETE FROM semantic_entries WHERE id = %s", (entry_id,))
-            return cur.rowcount > 0
+            rowcount: int = int(cur.rowcount or 0)
+            return rowcount > 0

--- a/src/riks_context_engine/multi_tenant.py
+++ b/src/riks_context_engine/multi_tenant.py
@@ -1,0 +1,105 @@
+"""Multi-tenant isolation primitives (#102).
+
+Every context / memory operation is scoped to a tenant. A tenant is
+identified by an opaque string; the engine never mixes data across
+tenants:
+
+- HTTP layer: ``TenantAuthMiddleware`` validates the ``X-Tenant-Id``
+  header on protected paths (missing/empty/invalid -> 401, consistent).
+- MCP layer: context tools are served from per-tenant
+  :class:`ContextWindowManager` instances created by
+  :class:`TenantContextRegistry`, so tenant A's context window is
+  structurally invisible to tenant B.
+- Query filter: :func:`assert_same_tenant` guards any direct query that
+  could leak one tenant's records to another.
+
+Scope note: tenant registration/management and RBAC are OUT of scope
+here (tracked under #110 access control). This module only enforces
+isolation + header validation.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+
+from riks_context_engine.context.manager import ContextWindowManager
+
+#: Header carrying the tenant identifier on HTTP requests.
+TENANT_HEADER = "X-Tenant-Id"
+
+#: Tenant ids must be 1-64 chars of [a-zA-Z0-9._-]. This rejects empty
+#: ids, whitespace, path separators, control chars and header
+#: injection attempts in one consistent rule (all violations -> 401).
+TENANT_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+
+class TenantValidationError(Exception):
+    """Raised when a tenant identifier is missing or malformed."""
+
+    def __init__(self, detail: str):
+        super().__init__(detail)
+        self.detail = detail
+
+
+def validate_tenant_id(raw: str | None) -> str:
+    """Validate a raw tenant id; return it normalized (trimmed).
+
+    Raises:
+        TenantValidationError: if missing, empty, or malformed.
+    """
+    if raw is None:
+        raise TenantValidationError(f"Missing {TENANT_HEADER} header")
+    tenant = raw.strip()
+    if not tenant:
+        raise TenantValidationError(f"{TENANT_HEADER} header is empty")
+    if not TENANT_ID_RE.match(tenant):
+        raise TenantValidationError(
+            f"Invalid {TENANT_HEADER}: must match [A-Za-z0-9._-] (1-64 chars)"
+        )
+    return tenant
+
+
+def assert_same_tenant(requested: str | None, record_tenant: str, field: str = "record") -> None:
+    """Guard a query so it can only ever touch the caller's own tenant.
+
+    Raises:
+        TenantValidationError: when ``requested`` differs from the
+        record's tenant. Callers map this to 404/403 so that foreign
+        records are indistinguishable from non-existent ones.
+    """
+    if requested is None or requested != record_tenant:
+        # Do NOT echo the record's tenant id in the error (no oracle).
+        raise TenantValidationError(f"{field} does not belong to this tenant")
+
+
+class TenantContextRegistry:
+    """Per-tenant :class:`ContextWindowManager` instances.
+
+    Isolation is structural: each tenant gets its own manager, so a
+    query for tenant B can never see tenant A's messages — there is no
+    shared list to filter.
+    """
+
+    def __init__(self, max_tokens: int = 50_000) -> None:
+        self._managers: dict[str, ContextWindowManager] = {}
+        self._lock = threading.Lock()
+        self._max_tokens = max_tokens
+
+    def get(self, tenant_id: str) -> ContextWindowManager:
+        """Return the context manager for ``tenant_id`` (creating it if needed).
+
+        Args:
+            tenant_id: A *validated* tenant id (run through
+                :func:`validate_tenant_id` first).
+        """
+        with self._lock:
+            mgr = self._managers.get(tenant_id)
+            if mgr is None:
+                mgr = ContextWindowManager(max_tokens=self._max_tokens)
+                self._managers[tenant_id] = mgr
+            return mgr
+
+    def has(self, tenant_id: str) -> bool:
+        with self._lock:
+            return tenant_id in self._managers

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -100,6 +100,13 @@ class TestToolSchemas:
         assert schema is not None
         assert "role" in schema["inputSchema"]["required"]
         assert "content" in schema["inputSchema"]["required"]
+        # #102: tenant isolation makes tenant_id a required param
+        assert "tenant_id" in schema["inputSchema"]["required"]
+
+    def test_context_get_summary_requires_tenant(self) -> None:
+        schema = get_tool_schema("context_get_summary")
+        assert schema is not None
+        assert "tenant_id" in schema["inputSchema"]["required"]
 
     def test_list_tools_returns_all(self) -> None:
         tools = list_tools()
@@ -169,7 +176,7 @@ class TestMCPServer:
         result = server.handle_tools_call(
             {
                 "name": "context_add_message",
-                "arguments": {"role": "user", "content": "Hello world"},
+                "arguments": {"tenant_id": "t-mcp", "role": "user", "content": "Hello world"},
             }
         )
         assert "content" in result
@@ -178,7 +185,9 @@ class TestMCPServer:
         assert "added" in text
 
     def test_context_get_summary(self, server: MCPServer) -> None:
-        result = server.handle_tools_call({"name": "context_get_summary", "arguments": {}})
+        result = server.handle_tools_call(
+            {"name": "context_get_summary", "arguments": {"tenant_id": "t-mcp"}}
+        )
         assert "content" in result
         text = result["content"][0]["text"]
         # Should contain token stats
@@ -317,7 +326,11 @@ class TestMCPIntegration:
                 "method": "tools/call",
                 "params": {
                     "name": "context_add_message",
-                    "arguments": {"role": "user", "content": "test message"},
+                    "arguments": {
+                        "tenant_id": "t-integ",
+                        "role": "user",
+                        "content": "test message",
+                    },
                 },
             },
         )
@@ -331,7 +344,10 @@ class TestMCPIntegration:
                 "jsonrpc": "2.0",
                 "id": 4,
                 "method": "tools/call",
-                "params": {"name": "context_get_summary", "arguments": {}},
+                "params": {
+                    "name": "context_get_summary",
+                    "arguments": {"tenant_id": "t-integ"},
+                },
             },
         )
         assert summary_resp is not None

--- a/tests/test_tenant_isolation.py
+++ b/tests/test_tenant_isolation.py
@@ -1,0 +1,203 @@
+"""Tests for multi-tenant isolation (#102).
+
+Covers:
+1. Tenant ID header validation — missing/empty/malformed -> 401 (consistent)
+2. Context query isolation — tenant A cannot read tenant B's context
+3. Regression: existing endpoints still work with a valid tenant header
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from riks_context_engine.api import server as server_module
+from riks_context_engine.api.server import app
+from riks_context_engine.multi_tenant import (
+    TENANT_HEADER,
+    TenantContextRegistry,
+    TenantValidationError,
+    assert_same_tenant,
+    validate_tenant_id,
+)
+
+VALID_TENANT = "tenant-a"
+VALID_TENANT_B = "tenant-b"
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _headers(tenant: str | None = VALID_TENANT) -> dict[str, str]:
+    if tenant is None:
+        return {}
+    return {TENANT_HEADER: tenant}
+
+
+# ─── 1. Header validation (criterion 1) ──────────────────────────────────────
+
+
+class TestTenantHeaderValidation:
+    """Missing or malformed X-Tenant-Id must be rejected with 401."""
+
+    def test_missing_header_rejected_401(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/context/summary")
+        assert resp.status_code == 401
+        assert "X-Tenant-Id" in resp.json()["detail"]
+
+    def test_empty_header_rejected_401(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/context/summary", headers=_headers(""))
+        assert resp.status_code == 401
+
+    def test_whitespace_header_rejected_401(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/context/summary", headers=_headers("   "))
+        assert resp.status_code == 401
+
+    def test_malformed_header_rejected_401(self, client: TestClient) -> None:
+        # Path separator / header-injection attempt
+        resp = client.get("/api/v1/context/summary", headers=_headers("tenant/../etc"))
+        assert resp.status_code == 401
+
+    def test_overlong_header_rejected_401(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/context/summary", headers=_headers("a" * 65))
+        assert resp.status_code == 401
+
+    def test_valid_header_accepted_200(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/context/summary", headers=_headers())
+        assert resp.status_code == 200
+        assert "current_tokens" in resp.json()
+
+    def test_health_unprotected_no_tenant_needed(self, client: TestClient) -> None:
+        # /health is outside the protected set -> works without tenant header
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+
+class TestValidateTenantIdUnit:
+    def test_valid(self) -> None:
+        assert validate_tenant_id("tenant-1.x") == "tenant-1.x"
+
+    def test_strips_whitespace(self) -> None:
+        assert validate_tenant_id("  tenant-1  ") == "tenant-1"
+
+    @pytest.mark.parametrize(
+        "raw",
+        [None, "", "   ", "a" * 65, "tenant/../x", "tenant name", "t\nx", "é"],
+    )
+    def test_invalid_raises(self, raw: object) -> None:
+        with pytest.raises(TenantValidationError):
+            validate_tenant_id(raw)  # type: ignore[arg-type]
+
+
+class TestAssertSameTenantUnit:
+    def test_same_ok(self) -> None:
+        assert_same_tenant("t1", "t1")
+
+    @pytest.mark.parametrize("req", [None, "t2", ""])
+    def test_foreign_raises(self, req: str | None) -> None:
+        with pytest.raises(TenantValidationError):
+            assert_same_tenant(req, "t1")
+
+
+# ─── 2. Context isolation (criterion 2) ──────────────────────────────────────
+
+
+class TestContextIsolation:
+    """Tenant A's context must be invisible to tenant B."""
+
+    def test_tenant_b_cannot_see_tenant_a_messages(self, client: TestClient) -> None:
+        # Tenant A writes 3 messages
+        for i in range(3):
+            resp = client.post(
+                "/api/v1/context/messages",
+                json={"role": "user", "content": f"A-secret-{i}"},
+                headers=_headers(VALID_TENANT),
+            )
+            assert resp.status_code == 200, resp.text
+
+        # Tenant A sees its own 3 messages
+        resp_a = client.get("/api/v1/context/messages", headers=_headers(VALID_TENANT))
+        assert resp_a.status_code == 200
+        assert len(resp_a.json()) == 3
+
+        # Tenant B sees ZERO messages (isolation), not tenant A's
+        resp_b = client.get("/api/v1/context/messages", headers=_headers(VALID_TENANT_B))
+        assert resp_b.status_code == 200
+        assert resp_b.json() == []
+
+    def test_tenant_summary_isolated(self, client: TestClient) -> None:
+        client.post(
+            "/api/v1/context/messages",
+            json={"role": "assistant", "content": "isolated-payload"},
+            headers=_headers(VALID_TENANT),
+        )
+        summary_a = client.get(
+            "/api/v1/context/summary", headers=_headers(VALID_TENANT)
+        ).json()
+        summary_b = client.get(
+            "/api/v1/context/summary", headers=_headers(VALID_TENANT_B)
+        ).json()
+        assert summary_a["messages_count"] > 0
+        assert summary_b["messages_count"] == 0
+
+    def test_registry_structural_isolation(self) -> None:
+        reg = TenantContextRegistry(max_tokens=1000)
+        mgr_a = reg.get("alpha")
+        mgr_b = reg.get("beta")
+        mgr_a.add(role="user", content="alpha-only")
+        assert len(mgr_b.get_messages(include_pruned=False)) == 0
+        # Same manager instance per tenant, distinct across tenants
+        assert reg.get("alpha") is mgr_a
+        assert reg.get("beta") is mgr_b
+        assert mgr_a is not mgr_b
+
+
+# ─── 3. MCP tool isolation (tenant_id param) ─────────────────────────────────
+
+
+class TestMcpTenantIsolation:
+    def test_mcp_context_summary_isolated(self) -> None:
+        from riks_context_engine.mcp.handlers import ToolHandler
+
+        handler = ToolHandler(data_dir="/tmp/ora-test-mcp")
+        r_a = handler.context_add_message(
+            {"tenant_id": "mcp-a", "role": "user", "content": "mcp-a-data"}
+        )
+        assert r_a["status"] == "added"
+
+        summary_a = handler.context_get_summary({"tenant_id": "mcp-a"})
+        summary_b = handler.context_get_summary({"tenant_id": "mcp-b"})
+        assert summary_a["messages_count"] >= 1
+        assert summary_b["messages_count"] == 0
+
+    def test_mcp_missing_tenant_rejected(self) -> None:
+        from riks_context_engine.mcp.handlers import TenantIsolationError, ToolHandler
+
+        handler = ToolHandler(data_dir="/tmp/ora-test-mcp2")
+        with pytest.raises(TenantIsolationError):
+            handler.context_add_message({"role": "user", "content": "no-tenant"})
+
+    def test_mcp_malformed_tenant_rejected(self) -> None:
+        from riks_context_engine.mcp.handlers import TenantIsolationError, ToolHandler
+
+        handler = ToolHandler(data_dir="/tmp/ora-test-mcp3")
+        with pytest.raises(TenantIsolationError):
+            handler.context_get_summary({"tenant_id": "bad tenant!!"})
+
+
+# ─── 4. Regression: existing endpoints with a valid tenant header ────────────
+
+
+class TestRegression:
+    def test_chat_requires_no_tenant_still_works(self, client: TestClient) -> None:
+        # /api/chat is protected (API key) but we only test that tenant
+        # middleware doesn't break the request path when header is present.
+        resp = client.post(
+            "/api/chat",
+            json={"message": "hi"},
+            headers=_headers(),
+        )
+        assert resp.status_code == 200
+        assert "hi" in resp.json()["response"]

--- a/tests/test_tenant_isolation.py
+++ b/tests/test_tenant_isolation.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-from riks_context_engine.api import server as server_module
 from riks_context_engine.api.server import app
 from riks_context_engine.multi_tenant import (
     TENANT_HEADER,
@@ -133,12 +132,8 @@ class TestContextIsolation:
             json={"role": "assistant", "content": "isolated-payload"},
             headers=_headers(VALID_TENANT),
         )
-        summary_a = client.get(
-            "/api/v1/context/summary", headers=_headers(VALID_TENANT)
-        ).json()
-        summary_b = client.get(
-            "/api/v1/context/summary", headers=_headers(VALID_TENANT_B)
-        ).json()
+        summary_a = client.get("/api/v1/context/summary", headers=_headers(VALID_TENANT)).json()
+        summary_b = client.get("/api/v1/context/summary", headers=_headers(VALID_TENANT_B)).json()
         assert summary_a["messages_count"] > 0
         assert summary_b["messages_count"] == 0
 


### PR DESCRIPTION
Closes #102.

## Kabul Kriterleri (issue'daki 3 madde)

**1. Tenant ID header validation** — `TenantAuthMiddleware` tüm korumalı path'lerde `X-Tenant-Id`'yi doğruluyor. Eksik/boş/whitespace/geçersiz karakter/64+ karakter → **401** (tutarlı sözleşme). Regex: `[A-Za-z0-9._-]{1,64}` (header injection + path separator'ı red ediyor).

**2. Context query'lerine tenant filter** — `TenantContextRegistry`: tenant başına ayrı `ContextWindowManager`. İzolasyon **yapısal** — ortak liste yok, tenant B'nin A'nın mesajlarını görmesi için filtre değil, ayrı yapı gerekiyor (imkânsız). Yeni tenant-scoped endpoint'ler:
- `POST /api/v1/context/messages`
- `GET /api/v1/context/messages`
- `GET /api/v1/context/summary`

MCP tool'ları (`context_add_message`, `context_get_summary`) artık `tenant_id` parametresi **required** (schema zorunlu); eksik/geçersiz → `TenantIsolationError`.

**3. Test coverage** — `tests/test_tenant_isolation.py` 28 yeni test:
- Header validation: 401 contract (missing/empty/whitespace/malformed/overlong) + valid → 200
- **İzolasyon kanıtı:** tenant A 3 mesaj yazar → tenant B `GET` yapınca 0 mesaj görür; summary da izole
- Registry yapısal izolasyon (aynı tenant → aynı manager, farklı tenant → farklı manager)
- MCP tenant scoping + missing/malformed tenant reddi
- Regresyon: mevcut endpoint'ler geçerli header ile çalışıyor

Toplam: **413 passed / 99 skipped** (önceki: 384/98 → +28 test, 0 regresyon)

## Kapsam Dışı (#110'a ait)
Tenant kayıt/mgmt endpoint'leri, RBAC — bu ticket'ta yok.

## Ek
- `PostgresSemanticMemory.delete` mypy `no-any-return` fix'i (#104 squash'ta kaybolmuştu, geri alındı)
- CI yeşil kalır: ruff ✓, mypy ✓, pre-commit ✓, pytest ✓ (lokal doğrulandı)