### PR TITLE
ci(pr-labels): explicit job permissions for PR Labels token (#117)

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -164,6 +164,17 @@ jobs:
     name: PR Labels
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'labeled')
+    # Explicit minimum token scope (#117): the job declares exactly what it
+    # needs so a missing repo-level grant fails fast with a clear error.
+    permissions:
+      pull-requests: read
+      issues: write
+      contents: read
+    # NOTE (#117): this job also requires the repo-level GITHUB_TOKEN scope
+    # "Workflow permissions: read and write" (Settings -> Developer tools
+    # -> GitHub Actions). Minimum required scope: issues: write (labels
+    # live on the issues API). If the repo default is read-only, label
+    # writes fail with "Resource not accessible by integration".
     steps:
       - name: Check size
         uses: actions/github-script@v7


### PR DESCRIPTION
Partial fix for #117 (automation cleanup, P2).

## What changed (workflow files)
Only `.github/workflows/issues.yml`:
- `pr-labels` job now declares explicit `permissions:` (pull-requests: read, issues: write, contents: read) + a comment documenting the repo-level requirement.
- No other workflow touched. No env var introduced — token scope is a Settings-level control, not a secret.

## Proof (AC-2, partial — honest)
- PR #118 (throwaway test PR, since closed) triggered the job on the fix branch.
- Run log confirms the job now reaches `addLabels` and the failure mode is the **token permission** (403 "Resource not accessible by integration"), not the old legacy-namespace crash.
- A fully green Labels run + applied label requires AC-1 (repo Settings → Developer tools → GitHub Actions → Workflow permissions = read/write), which is a manual UI step the dev token cannot perform via API (403 on /actions/permissions).

## What remains (manual)
1. Settings → Developer tools → GitHub Actions → Workflow permissions: **read and write** (minimum: issues: write).
2. Re-open a test PR → PR Labels check green + size label applied.

CI impact: none on the 3 green checks (lint/type/test) — workflow-only diff.