### PR TITLE
fix(cd): trivy sarif as artifact — makes CD Pipeline green on master (#117)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -141,10 +141,19 @@ jobs:
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
 
+      # codeql-action needs the security-events:write scope which the
+      # repo's GITHUB_TOKEN lacks ("Resource not accessible by integration").
+      # Upload the SARIF as a regular artifact instead: the vulnerability
+      # findings remain available (Actions run page -> Artifacts) and the
+      # scan gate (trivy exit code) is unaffected.
       - name: Upload Trivy results
-        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          sarif_file: trivy-results.sarif
+          name: trivy-results
+          path: trivy-results.sarif
+          if-no-files-found: warn
+          retention-days: 14
 
   # ===== Stage 3: Deploy to Staging (Master Push) ===== #
   deploy-staging:


### PR DESCRIPTION
Follow-up to the #117 Trivy fix (merged as 1f2fb07). That merge fixed the
scan itself (Docker Build & Scan now green on PRs), but the CD Pipeline on
master still failed at the **upload** step:

```
codeql-action/upload-sarif@v3 → Resource not accessible by integration
(needs security-events:write, which the repo GITHUB_TOKEN lacks)
```

This commit replaces the CodeQL SARIF upload with a plain Actions artifact
(14-day retention). The scan gate (trivy exit code on CRITICAL/HIGH) is
unchanged; findings remain available under the run's Artifacts.

AC proof:
- CD Pipeline on the PR: all jobs pass (see checks).
- After merge: master push CD Pipeline run expected green — run id in the
  [SONUÇ] report.