### PR TITLE
feat(reflection): real LLM-based reflection analyzer (issue #126)

### DIFF
--- a/src/riks_context_engine/reflection/analyzer.py
+++ b/src/riks_context_engine/reflection/analyzer.py
@@ -1,11 +1,23 @@
-"""Self-reflection analyzer - learn from mistakes and successes."""
+"""Self-reflection analyzer - learn from mistakes and successes.
+
+The analyzer performs a real LLM-based reflection over a conversation
+(via Ollama) to produce structured "what went well / what went wrong"
+insights. When the LLM is unavailable or fails, it falls back to a
+deterministic, content-based heuristic that still extracts concrete
+observations from the conversation text (not just metadata).
+"""
+
+from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -33,6 +45,8 @@ class ReflectionReport:
     missing_info: list[str] = field(default_factory=list)
     lessons: list[Lesson] = field(default_factory=list)
     timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    # Which path produced this report: "llm" | "fallback"
+    source: str = "fallback"
 
 
 # Category detection patterns
@@ -78,6 +92,10 @@ CATEGORY_PATTERNS = {
     ],
 }
 
+# Canonical category names the LLM is allowed to emit
+VALID_CATEGORIES: frozenset[str] = frozenset(CATEGORY_PATTERNS) | frozenset({"general"})
+VALID_SEVERITIES = ("info", "warning", "critical")
+
 
 def detect_category(text: str) -> list[str]:
     """Detect categories from text using pattern matching."""
@@ -101,22 +119,132 @@ def extract_severity(text: str) -> str:
     return "info"
 
 
+def _sanitize_category(value: object) -> str:
+    """Normalize a category value to one of the known categories."""
+    if isinstance(value, str):
+        normalized = value.strip().lower().replace(" ", "-").replace("_", "-")
+        if normalized in VALID_CATEGORIES:
+            return normalized
+    return "general"
+
+
+def _sanitize_severity(value: object) -> str:
+    """Normalize a severity value to one of the known severities."""
+    if isinstance(value, str) and value.strip().lower() in VALID_SEVERITIES:
+        return value.strip().lower()
+    return "info"
+
+
+# ---------------------------------------------------------------------------
+# LLM prompt templates
+# ---------------------------------------------------------------------------
+
+_REFLECT_SYSTEM_PROMPT = """You are a self-reflection analyst for an AI agent. Given a conversation, analyze what happened and extract actionable lessons.
+
+Output a JSON object with EXACTLY this shape (no markdown, no extra keys):
+{
+  "went_well": ["short factual statement of what worked well"],
+  "went_wrong": ["short factual statement of what went wrong or caused problems"],
+  "missing_info": ["information that was missing or had to be guessed"],
+  "lessons": [
+    {
+      "category": "tool-use" | "context-management" | "task-planning" | "communication" | "security" | "general",
+      "observation": "what was observed in the conversation (max 200 chars)",
+      "lesson_text": "an actionable lesson the agent should remember (max 300 chars)",
+      "severity": "info" | "warning" | "critical"
+    }
+  ]
+}
+
+Rules:
+- Base every statement ONLY on the conversation content; never invent events.
+- Be specific: quote concrete errors, names, values, or steps when present.
+- "went_well" and "went_wrong" are the core answer: what actually went well / wrong in this session.
+- Use at most 5 items per list and at most 5 lessons.
+- Severity "critical" only for data loss, security issues, or destructive failures.
+- Return valid JSON only."""
+
+_REFLECT_USER_PROMPT = """Reflect on this conversation and extract lessons.
+
+Conversation:
+---
+{conversation}
+---"""
+
+
+def _render_conversation(conversation: list[dict], max_chars: int = 12000) -> str:
+    """Render a conversation to compact text for the LLM prompt."""
+    lines = []
+    total = 0
+    for msg in conversation:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role", "unknown"))
+        content = str(msg.get("content", "")).strip()
+        if not content:
+            continue
+        line = f"[{role}] {content[:500]}"
+        if total + len(line) > max_chars:
+            lines.append("... (truncated)")
+            break
+        lines.append(line)
+        total += len(line)
+    return "\n".join(lines)
+
+
 class ReflectionAnalyzer:
     """Analyzes interactions to extract lessons and track improvement.
 
-    After each significant interaction, runs a lightweight self-check
-    to identify what went well, what failed, and what information
-    was missing.
+    After each significant interaction, runs a real LLM-based reflection
+    (Ollama) over the conversation content to identify what went well,
+    what failed, and what information was missing. Falls back to a
+    content-based heuristic when the LLM is unavailable.
+
+    Parameters
+    ----------
+    semantic_memory :
+        Optional semantic memory backend (used by ``record_success``).
+    storage_path :
+        Where lessons are persisted (JSON). Defaults to the
+        ``REFLECTION_STORAGE`` env var or ``data/lessons.json``.
+    llm_model :
+        Ollama model name. Defaults to the ``OLLAMA_MODEL`` env var
+        (same convention as the rest of the engine), else "qwen3.5-9b".
+    llm_base_url :
+        Ollama base URL. Defaults to the ``OLLAMA_BASE_URL`` env var,
+        else ``http://localhost:11434``.
+    llm_timeout :
+        Per-call timeout in seconds.
+    fallback_top_n :
+        Number of most important messages the fallback summarizes.
     """
 
-    def __init__(self, semantic_memory=None, storage_path: str | None = None):
+    DEFAULT_MODEL = "qwen3.5-9b"
+
+    def __init__(
+        self,
+        semantic_memory=None,
+        storage_path: str | None = None,
+        llm_model: str | None = None,
+        llm_base_url: str | None = None,
+        llm_timeout: float = 60.0,
+        fallback_top_n: int = 3,
+    ):
         self.semantic_memory = semantic_memory
+        self.llm_model = llm_model or os.environ.get("OLLAMA_MODEL") or self.DEFAULT_MODEL
+        self.llm_base_url = llm_base_url or os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434"
+        self.llm_timeout = llm_timeout
+        self.fallback_top_n = max(1, int(fallback_top_n))
         self._lessons: dict[str, Lesson] = {}
         self._mistake_counts: dict[str, int] = {}
         self.storage_path = storage_path or os.environ.get(
             "REFLECTION_STORAGE", "data/lessons.json"
         )
         self.load()
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
 
     def save(self) -> None:
         """Persist active lessons to disk."""
@@ -126,13 +254,16 @@ class ReflectionAnalyzer:
             "mistake_counts": self._mistake_counts,
             "saved_at": datetime.now(timezone.utc).isoformat(),
         }
-        Path(self.storage_path).parent.mkdir(parents=True, exist_ok=True)
+        if self.storage_path == ":memory:":
+            return  # ":memory:" is used by tests to avoid disk writes
+        path = Path(self.storage_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
         with open(self.storage_path, "w") as f:
             json.dump(data, f, indent=2, default=str)
 
     def load(self) -> None:
         """Load lessons from disk if available."""
-        if not os.path.exists(self.storage_path):
+        if self.storage_path == ":memory:" or not os.path.exists(self.storage_path):
             return
         try:
             with open(self.storage_path) as f:
@@ -148,76 +279,279 @@ class ReflectionAnalyzer:
         except (json.JSONDecodeError, KeyError, TypeError):
             pass  # Ignore corrupt files
 
+    # ------------------------------------------------------------------
+    # Analysis
+    # ------------------------------------------------------------------
+
     def analyze(self, interaction_id: str, conversation: list[dict]) -> ReflectionReport:
-        """Analyze an interaction and generate a reflection report."""
-        went_well = []
-        went_wrong = []
-        missing_info = []
+        """Analyze an interaction and generate a reflection report.
 
-        # Simple pattern-based analysis
-        for msg in conversation:
-            content = msg.get("content", "")
-            _role = msg.get("role", "")
+        Tries a real LLM call (Ollama) over the conversation content and
+        parses the structured response. If the LLM is unavailable, fails,
+        or returns an unparseable result, falls back to a deterministic
+        content-based analysis of the most important messages.
+        """
+        messages = [m for m in conversation if isinstance(m, dict)]
+        if not messages:
+            return ReflectionReport(interaction_id=interaction_id, source="fallback")
 
-            # Look for success indicators
-            if any(
-                kw in content.lower() for kw in ["success", "works", "solved", "fixed", "great"]
-            ):
-                went_well.append(content[:200])
+        # 1) Try the LLM path (real content analysis)
+        try:
+            result = self._reflect_with_llm(messages)
+        except Exception as exc:  # network, model, import errors
+            logger.warning("LLM reflection failed, using fallback: %s", exc)
+            result = None
 
-            # Look for failure indicators
-            has_error = any(
-                kw in content.lower()
-                for kw in ["error", "fail", "wrong", "bug", "issue", "problem"]
+        if result is not None:
+            report = ReflectionReport(
+                interaction_id=interaction_id,
+                went_well=result["went_well"],
+                went_wrong=result["went_wrong"],
+                missing_info=result["missing_info"],
+                lessons=result["lessons"],
+                source="llm",
             )
-            has_api = any(
-                kw in content.lower() for kw in ["timeout", "api", "http", "request", "endpoint"]
-            )
+        else:
+            # 2) Content-based fallback: summarize the most important N
+            #    messages and derive structured lessons from them.
+            report = self._analyze_fallback(interaction_id, messages)
 
-            if has_error or has_api:
-                went_wrong.append(content[:200])
-
-            # Look for missing info patterns
-            if (
-                "didn't know" in content.lower()
-                or "missing" in content.lower()
-                or "unclear" in content.lower()
-            ):
-                missing_info.append(content[:200])
-
-        # Extract lessons from what went wrong
-        lessons = []
-        for wrong in went_wrong:
-            categories = detect_category(wrong)
-            severity = extract_severity(wrong)
-
-            lesson_id = f"lesson_{len(self._lessons)}"
-            lesson = Lesson(
-                id=lesson_id,
-                category=categories[0],
-                observation=wrong[:100],
-                lesson_text=self._generate_lesson_text(wrong, categories[0]),
-                severity=severity,
-            )
-            lessons.append(lesson)
+        # Track lessons and mistake frequency (identical for both paths,
+        # so downstream behavior is backward compatible)
+        for lesson in report.lessons:
             self._add_lesson(lesson)
+            self._mistake_counts[lesson.category] = (
+                self._mistake_counts.get(lesson.category, 0) + 1
+            )
 
-        # Update mistake tracking
-        for lesson in lessons:
-            self._mistake_counts[lesson.category] = self._mistake_counts.get(lesson.category, 0) + 1
-
-        report = ReflectionReport(
-            interaction_id=interaction_id,
-            went_well=went_well[:5],  # Cap at 5
-            went_wrong=went_wrong[:5],
-            missing_info=missing_info[:5],
-            lessons=lessons,
-        )
         return report
 
-    def _generate_lesson_text(self, observation: str, category: str) -> str:
+    # -- LLM path ------------------------------------------------------
+
+    def _reflect_with_llm(self, messages: list[dict]) -> dict | None:
+        """Call Ollama to reflect on the conversation. Returns parsed dict
+        or None when unavailable/failed/unparseable."""
+        try:
+            import ollama
+        except ImportError:
+            logger.debug("ollama package not available, using reflection fallback")
+            return None
+
+        if not hasattr(ollama, "Client"):
+            # Module stub without a real client (e.g. partial import in tests)
+            logger.debug("ollama module has no Client, using reflection fallback")
+            return None
+
+        rendered = _render_conversation(messages)
+        if not rendered:
+            return None
+
+        try:
+            client = ollama.Client(host=self.llm_base_url, timeout=self.llm_timeout)
+            response = client.chat(
+                model=self.llm_model,
+                messages=[
+                    {"role": "system", "content": _REFLECT_SYSTEM_PROMPT},
+                    {"role": "user", "content": _REFLECT_USER_PROMPT.format(conversation=rendered)},
+                ],
+                options={"temperature": 0.2, "num_predict": 1024},
+            )
+            content = (response.message.content or "").strip()
+        except Exception as exc:  # pragma: no cover — network, model errors
+            logger.warning("Ollama reflection call failed: %s", exc)
+            return None
+
+        return self._parse_reflection_json(content)
+
+    @staticmethod
+    def _parse_reflection_json(content: str) -> dict | None:
+        """Parse and validate the LLM JSON output. Returns None on any
+        structural problem so the caller can fall back."""
+        if not content:
+            return None
+        # Strip markdown code fences if present
+        if content.startswith("```"):
+            content = content.split("\n", 1)[1]
+        if content.endswith("```"):
+            content = content.rsplit("\n", 1)[0]
+        content = content.strip()
+
+        # Extract the first JSON object if the model added prose around it
+        start = content.find("{")
+        end = content.rfind("}")
+        if start == -1 or end == -1 or end < start:
+            return None
+        try:
+            data = json.loads(content[start : end + 1])
+        except json.JSONDecodeError:
+            logger.debug("reflection LLM returned invalid JSON")
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        def _str_list(key: str, cap: int = 5) -> list[str]:
+            raw = data.get(key)
+            if not isinstance(raw, list):
+                return []
+            return [str(item).strip() for item in raw if str(item).strip()][:cap]
+
+        lessons: list[Lesson] = []
+        raw_lessons = data.get("lessons")
+        if isinstance(raw_lessons, list):
+            for item in raw_lessons[:5]:
+                if not isinstance(item, dict):
+                    continue
+                observation = str(item.get("observation", "")).strip()[:200]
+                lesson_text = str(item.get("lesson_text", "")).strip()[:300]
+                if not observation and not lesson_text:
+                    continue
+                category = _sanitize_category(item.get("category"))
+                severity = _sanitize_severity(item.get("severity"))
+                if severity == "info" and lesson_text:
+                    # Let the heuristic refine info-level severity from text
+                    severity = extract_severity(f"{observation} {lesson_text}")
+                lessons.append(
+                    Lesson(
+                        id=f"lesson_llm_{len(lessons)}",
+                        category=category,
+                        observation=observation,
+                        lesson_text=lesson_text,
+                        severity=severity,
+                    )
+                )
+
+        return {
+            "went_well": _str_list("went_well"),
+            "went_wrong": _str_list("went_wrong"),
+            "missing_info": _str_list("missing_info"),
+            "lessons": lessons,
+        }
+
+    # -- Fallback path ---------------------------------------------------
+
+    _SUCCESS_KEYWORDS = [
+        "success", "successfully", "works", "worked", "solved", "fixed",
+        "resolved", "completed", "great", "done",
+    ]
+    _FAILURE_KEYWORDS = [
+        "error", "failed", "failure", "wrong", "bug", "issue", "problem",
+        "exception", "timeout", "crash", "broke", "broken", "rejected",
+        "denied", "invalid", "mismatch", "conflict",
+    ]
+    _MISSING_KEYWORDS = ["didn't know", "i don't know", "missing", "unclear", "unknown", "assumed"]
+
+    def _message_importance(self, content: str) -> int:
+        """Score a message's importance for the fallback summary."""
+        lowered = content.lower()
+        score = sum(1 for kw in self._FAILURE_KEYWORDS if kw in lowered) * 2
+        score += sum(1 for kw in self._MISSING_KEYWORDS if kw in lowered)
+        score += sum(1 for kw in self._SUCCESS_KEYWORDS if kw in lowered)
+        # Concrete evidence (code, paths, URLs, error output) is high-signal
+        score += 1 if re.search(r"[\w/]+\.(py|js|ts|json|yml|yaml|sh|log)", content) else 0
+        score += 1 if re.search(r"\b(traceback|stack trace|error:)\b", lowered) else 0
+        return score
+
+    def _analyze_fallback(self, interaction_id: str, messages: list[dict]) -> ReflectionReport:
+        """Deterministic, content-based analysis.
+
+        Summarizes the N most important messages (by content signals, not
+        just metadata) and derives structured lessons from them.
+        """
+        went_well: list[str] = []
+        went_wrong: list[str] = []
+        missing_info: list[str] = []
+
+        for msg in messages:
+            content = str(msg.get("content", "")).strip()
+            if not content:
+                continue
+            lowered = content.lower()
+
+            if any(kw in lowered for kw in self._SUCCESS_KEYWORDS):
+                went_well.append(content[:200])
+            if any(kw in lowered for kw in self._FAILURE_KEYWORDS):
+                went_wrong.append(content[:200])
+            if any(kw in lowered for kw in self._MISSING_KEYWORDS):
+                missing_info.append(content[:200])
+
+        # Most important N messages form the basis of the fallback summary
+        ranked = sorted(
+            (str(m.get("content", "")).strip() for m in messages if str(m.get("content", "")).strip()),
+            key=lambda c: -self._message_importance(c),
+        )
+        top_messages = ranked[: self.fallback_top_n]
+
+        lessons: list[Lesson] = []
+        seen: set[str] = set()
+        # Priority order: failures first (lessons are about problems),
+        # then missing info, then notable successes.
+        pools = [
+            (went_wrong, "went_wrong"),
+            (missing_info, "missing_info"),
+            (went_well, "went_well"),
+        ]
+        for pool, pool_name in pools:
+            for item in pool:
+                if len(lessons) >= max(len(top_messages), 3):
+                    break
+                key = item[:80].lower()
+                if key in seen:
+                    continue
+                seen.add(key)
+                categories = detect_category(item)
+                severity = extract_severity(item)
+                if pool_name == "went_well":
+                    severity = "info"
+                lessons.append(
+                    Lesson(
+                        id=f"lesson_{len(lessons)}",
+                        category=categories[0],
+                        observation=item[:100],
+                        lesson_text=self._generate_lesson_text(item, categories[0], pool_name),
+                        severity=severity,
+                    )
+                )
+        # If nothing matched keywords but messages exist, summarize the top
+        # messages so the report is still content-based (not empty metadata)
+        if not lessons and top_messages:
+            for item in top_messages:
+                categories = detect_category(item)
+                lessons.append(
+                    Lesson(
+                        id=f"lesson_{len(lessons)}",
+                        category=categories[0],
+                        observation=item[:100],
+                        lesson_text=f"Notable exchange to review: {item[:80]}",
+                        severity="info",
+                    )
+                )
+
+        # Cap the summary lists, but always include the top-N message
+        # summaries in the report's went_wrong/went_well context
+        def _cap(items: list[str], extra: list[str]) -> list[str]:
+            merged = list(items)
+            for extra_item in extra:
+                if extra_item not in merged:
+                    merged.append(extra_item)
+            return merged[:5]
+
+        top_wrong = [c for c in top_messages if any(k in c.lower() for k in self._FAILURE_KEYWORDS)]
+        top_well = [c for c in top_messages if any(k in c.lower() for k in self._SUCCESS_KEYWORDS)]
+
+        return ReflectionReport(
+            interaction_id=interaction_id,
+            went_well=_cap(went_well, top_well),
+            went_wrong=_cap(went_wrong, top_wrong),
+            missing_info=missing_info[:5],
+            lessons=lessons,
+            source="fallback",
+        )
+
+    def _generate_lesson_text(self, observation: str, category: str, pool_name: str) -> str:
         """Generate a lesson text from observation."""
-        # Simple template-based generation
+        if pool_name == "went_well":
+            return f"Keep doing what worked: {observation[:80]}"
         templates = {
             "tool-use": f"Check tool parameters and error handling when encountering: {observation[:50]}",
             "context-management": f"Monitor context limits and preserve important info: {observation[:50]}",
@@ -238,6 +572,10 @@ class ReflectionAnalyzer:
                 return
         self._lessons[lesson.id] = lesson
         self.save()
+
+    # ------------------------------------------------------------------
+    # Consultation & tracking (consumers of the lessons)
+    # ------------------------------------------------------------------
 
     def consult_before_task(self, task_description: str) -> list[Lesson]:
         """Before starting a task, check for related past lessons."""

--- a/src/riks_context_engine/reflection/analyzer.py
+++ b/src/riks_context_engine/reflection/analyzer.py
@@ -232,7 +232,9 @@ class ReflectionAnalyzer:
     ):
         self.semantic_memory = semantic_memory
         self.llm_model = llm_model or os.environ.get("OLLAMA_MODEL") or self.DEFAULT_MODEL
-        self.llm_base_url = llm_base_url or os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434"
+        self.llm_base_url = (
+            llm_base_url or os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434"
+        )
         self.llm_timeout = llm_timeout
         self.fallback_top_n = max(1, int(fallback_top_n))
         self._lessons: dict[str, Lesson] = {}
@@ -320,9 +322,7 @@ class ReflectionAnalyzer:
         # so downstream behavior is backward compatible)
         for lesson in report.lessons:
             self._add_lesson(lesson)
-            self._mistake_counts[lesson.category] = (
-                self._mistake_counts.get(lesson.category, 0) + 1
-            )
+            self._mistake_counts[lesson.category] = self._mistake_counts.get(lesson.category, 0) + 1
 
         return report
 
@@ -431,13 +431,35 @@ class ReflectionAnalyzer:
     # -- Fallback path ---------------------------------------------------
 
     _SUCCESS_KEYWORDS = [
-        "success", "successfully", "works", "worked", "solved", "fixed",
-        "resolved", "completed", "great", "done",
+        "success",
+        "successfully",
+        "works",
+        "worked",
+        "solved",
+        "fixed",
+        "resolved",
+        "completed",
+        "great",
+        "done",
     ]
     _FAILURE_KEYWORDS = [
-        "error", "failed", "failure", "wrong", "bug", "issue", "problem",
-        "exception", "timeout", "crash", "broke", "broken", "rejected",
-        "denied", "invalid", "mismatch", "conflict",
+        "error",
+        "failed",
+        "failure",
+        "wrong",
+        "bug",
+        "issue",
+        "problem",
+        "exception",
+        "timeout",
+        "crash",
+        "broke",
+        "broken",
+        "rejected",
+        "denied",
+        "invalid",
+        "mismatch",
+        "conflict",
     ]
     _MISSING_KEYWORDS = ["didn't know", "i don't know", "missing", "unclear", "unknown", "assumed"]
 
@@ -477,7 +499,11 @@ class ReflectionAnalyzer:
 
         # Most important N messages form the basis of the fallback summary
         ranked = sorted(
-            (str(m.get("content", "")).strip() for m in messages if str(m.get("content", "")).strip()),
+            (
+                str(m.get("content", "")).strip()
+                for m in messages
+                if str(m.get("content", "")).strip()
+            ),
             key=lambda c: -self._message_importance(c),
         )
         top_messages = ranked[: self.fallback_top_n]

--- a/tests/test_reflection_llm.py
+++ b/tests/test_reflection_llm.py
@@ -116,7 +116,10 @@ CONVERSATION_PLANNING = [
         "role": "assistant",
         "content": "The migration missed step 3 (index rebuild) and left a dependency broken on the orders table.",
     },
-    {"role": "user", "content": "Roll back and redo it: backup first, then migrate, then rebuild indexes"},
+    {
+        "role": "user",
+        "content": "Roll back and redo it: backup first, then migrate, then rebuild indexes",
+    },
 ]
 
 CONVERSATION_SECURITY = [
@@ -162,7 +165,7 @@ LLM_RESPONSE_PLANNING = json.dumps(
         "went_well": ["A rollback plan was agreed on with the correct step order."],
         "went_wrong": [
             "The database migration was run before the backup, in the wrong order.",
-            "Step 3 (index rebuild) was missed, breaking a dependency on the orders table."
+            "Step 3 (index rebuild) was missed, breaking a dependency on the orders table.",
         ],
         "missing_info": ["The full migration checklist was not available to the agent."],
         "lessons": [
@@ -326,9 +329,7 @@ class TestReflectionFallback:
         assert report.went_well or report.went_wrong or report.missing_info
 
     def test_fallback_content_based_summary(self, no_ollama, tmp_path):
-        analyzer = ReflectionAnalyzer(
-            storage_path=str(tmp_path / "lessons.json"), fallback_top_n=3
-        )
+        analyzer = ReflectionAnalyzer(storage_path=str(tmp_path / "lessons.json"), fallback_top_n=3)
         report = analyzer.analyze("int-fb", CONVERSATION_PLANNING)
         assert report.source == "fallback"
         # The important failure messages are surfaced, not just metadata
@@ -347,7 +348,9 @@ class TestReflectionFallback:
         assert report.source == "fallback"
         # Even without keyword signals, the top messages are summarized
         assert len(report.lessons) >= 1
-        assert any("Paris" in lsn.observation or "France" in lsn.observation for lsn in report.lessons)
+        assert any(
+            "Paris" in lsn.observation or "France" in lsn.observation for lsn in report.lessons
+        )
 
     def test_empty_conversation(self, no_ollama):
         analyzer = ReflectionAnalyzer()

--- a/tests/test_reflection_llm.py
+++ b/tests/test_reflection_llm.py
@@ -1,0 +1,421 @@
+"""Integration tests for the reflection analyzer's LLM path (issue #126).
+
+These tests mock the Ollama client (``ollama.Client``) so the LLM path is
+deterministic and hermetic, covering three distinct conversation contents:
+
+1. A debugging session with tool/API failures and a resolution.
+2. A task-planning session with wrong ordering and missed steps.
+3. A security-incident session with a critical exposure.
+
+Plus: invalid-JSON fallback, connection-failure fallback, and config
+defaults (OLLAMA_MODEL / OLLAMA_BASE_URL env vars).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+
+import pytest
+
+from riks_context_engine.reflection.analyzer import (
+    _REFLECT_SYSTEM_PROMPT,
+    _REFLECT_USER_PROMPT,
+    ReflectionAnalyzer,
+    _render_conversation,
+)
+
+# ---------------------------------------------------------------------------
+# Fake ollama package
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_ollama(fake_ollama: types.ModuleType | None) -> None:
+    if fake_ollama is not None:
+        sys.modules["ollama"] = fake_ollama
+    else:
+        sys.modules.pop("ollama", None)
+
+
+def _make_fake_ollama_pairs(pairs) -> types.ModuleType:
+    """Build a fake ``ollama`` module whose Client.chat picks the LLM
+    response whose marker appears in the user prompt content.
+
+    Accepts either a single ``(marker, response)`` pair or a tuple of pairs.
+    """
+    if isinstance(pairs[0], str):
+        pairs = (pairs,)
+
+    class FakeMessage:
+        def __init__(self, content: str):
+            self.content = content
+
+    class FakeResponse:
+        def __init__(self, content: str):
+            self.message = FakeMessage(content)
+
+    def _user_content(messages) -> str:
+        return messages[1]["content"] if len(messages) > 1 else ""
+
+    class FakeClient:
+        def __init__(self, host=None, timeout=None, **kwargs):
+            self.host = host
+            self.timeout = timeout
+
+        def chat(self, model, messages, options=None):
+            marker = next((m for m, _r in pairs if m in _user_content(messages)), None)
+            if marker is None:
+                return FakeResponse("ERROR: unexpected conversation")
+            return FakeResponse(dict(pairs)[marker])
+
+    module = types.ModuleType("ollama")
+    module.Client = FakeClient  # type: ignore[attr-defined]
+    return module
+
+
+@pytest.fixture
+def no_ollama():
+    """Make the real ollama package unimportable (force fallback).
+
+    Pops the module AND any loaded submodules so a later ``import ollama``
+    resolves to a module missing the ``Client`` attribute (ImportError).
+    """
+    loaded = [k for k in sys.modules if k == "ollama" or k.startswith("ollama.")]
+    saved = {k: sys.modules[k] for k in loaded}
+    for k in loaded:
+        del sys.modules[k]
+    yield
+    sys.modules.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# Test conversations (distinct contents)
+# ---------------------------------------------------------------------------
+
+CONVERSATION_DEBUGGING = [
+    {"role": "user", "content": "Deploy the payment service to staging"},
+    {
+        "role": "assistant",
+        "content": "I ran the deploy script but it failed with: Error: API timeout on /v1/checkout",
+    },
+    {"role": "user", "content": "Check the timeout config and retry with a longer window"},
+    {
+        "role": "assistant",
+        "content": "Increased the timeout in config.yaml and redeployed. Success: all endpoints healthy now.",
+    },
+]
+
+CONVERSATION_PLANNING = [
+    {"role": "user", "content": "Migrate the database to the new schema"},
+    {
+        "role": "assistant",
+        "content": "I ran the migration before backing up the database, which was the wrong order.",
+    },
+    {
+        "role": "assistant",
+        "content": "The migration missed step 3 (index rebuild) and left a dependency broken on the orders table.",
+    },
+    {"role": "user", "content": "Roll back and redo it: backup first, then migrate, then rebuild indexes"},
+]
+
+CONVERSATION_SECURITY = [
+    {"role": "user", "content": "The admin panel is showing an error page"},
+    {
+        "role": "assistant",
+        "content": "I found the database password was hardcoded in app.py and exposed in the error traceback.",
+    },
+    {
+        "role": "user",
+        "content": "Rotate the credential immediately and fix the validation so the error message does not leak data.",
+    },
+]
+
+# ---------------------------------------------------------------------------
+# LLM responses (deterministic, distinct per conversation)
+# ---------------------------------------------------------------------------
+
+LLM_RESPONSE_DEBUGGING = json.dumps(
+    {
+        "went_well": [
+            "Retrying the deploy after adjusting the timeout in config.yaml succeeded and endpoints are healthy."
+        ],
+        "went_wrong": [
+            "The deploy script failed with an API timeout on /v1/checkout before the timeout was increased."
+        ],
+        "missing_info": [
+            "The configured timeout value for the checkout API was not known initially."
+        ],
+        "lessons": [
+            {
+                "category": "tool-use",
+                "observation": "Deploy script failed with API timeout on /v1/checkout.",
+                "lesson_text": "Increase the API timeout window before deploying to staging when the target endpoint is slow.",
+                "severity": "warning",
+            }
+        ],
+    }
+)
+
+LLM_RESPONSE_PLANNING = json.dumps(
+    {
+        "went_well": ["A rollback plan was agreed on with the correct step order."],
+        "went_wrong": [
+            "The database migration was run before the backup, in the wrong order.",
+            "Step 3 (index rebuild) was missed, breaking a dependency on the orders table."
+        ],
+        "missing_info": ["The full migration checklist was not available to the agent."],
+        "lessons": [
+            {
+                "category": "task-planning",
+                "observation": "Migration executed before backup; wrong order of steps.",
+                "lesson_text": "Always back up the database before running a schema migration.",
+                "severity": "critical",
+            },
+            {
+                "category": "task-planning",
+                "observation": "Missed step 3 (index rebuild) left a dependency broken.",
+                "lesson_text": "Verify every migration step, including index rebuilds, before declaring the task done.",
+                "severity": "warning",
+            },
+        ],
+    }
+)
+
+LLM_RESPONSE_SECURITY = json.dumps(
+    {
+        "went_well": [],
+        "went_wrong": [
+            "The database password was hardcoded in app.py and exposed in an error traceback."
+        ],
+        "missing_info": ["It was unclear how the credential was originally stored."],
+        "lessons": [
+            {
+                "category": "security",
+                "observation": "Credential exposed in an error traceback.",
+                "lesson_text": "Never hardcode credentials; rotate any exposed credential immediately and sanitize error pages.",
+                "severity": "critical",
+            }
+        ],
+    }
+)
+
+
+def _responses_by_content(*pairs: tuple[str, str]):
+    """Return the (marker, response) pairs for _make_fake_ollama_pairs."""
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (LLM path, mocked Ollama)
+# ---------------------------------------------------------------------------
+
+
+class TestReflectionLLMIntegration:
+    """analyze() must perform a real (mocked) LLM call and produce a
+    structured, content-based report for distinct session contents."""
+
+    def test_debugging_session(self, tmp_path):
+        _install_fake_ollama(_make_fake_ollama_pairs(("/v1/checkout", LLM_RESPONSE_DEBUGGING)))
+        try:
+            analyzer = ReflectionAnalyzer(storage_path=str(tmp_path / "lessons.json"))
+            report = analyzer.analyze("int-debug", CONVERSATION_DEBUGGING)
+        finally:
+            _install_fake_ollama(None)
+
+        assert report.source == "llm"
+        assert report.interaction_id == "int-debug"
+        # Structured output is content-based, not just metadata
+        assert any("/v1/checkout" in w for w in report.went_wrong)
+        assert any("timeout" in w.lower() or "config.yaml" in w for w in report.went_well)
+        assert len(report.lessons) == 1
+        lesson = report.lessons[0]
+        assert lesson.category == "tool-use"
+        assert lesson.severity == "warning"
+        assert "/v1/checkout" in lesson.observation
+        # Lessons are consumed by consult_before_task
+        relevant = analyzer.consult_before_task("Deploy and call the checkout API")
+        assert any(lsn.id == lesson.id for lsn in relevant)
+        # Persistence happened (real file write on the LLM path)
+        assert (tmp_path / "lessons.json").exists()
+
+    def test_planning_session(self, tmp_path):
+        _install_fake_ollama(_make_fake_ollama_pairs(("wrong order", LLM_RESPONSE_PLANNING)))
+        try:
+            analyzer = ReflectionAnalyzer(storage_path=str(tmp_path / "lessons.json"))
+            report = analyzer.analyze("int-plan", CONVERSATION_PLANNING)
+        finally:
+            _install_fake_ollama(None)
+
+        assert report.source == "llm"
+        assert len(report.went_wrong) == 2
+        assert any("backup" in w for w in report.went_wrong)
+        assert len(report.lessons) == 2
+        severities = {lsn.severity for lsn in report.lessons}
+        assert severities == {"critical", "warning"}
+        assert all(lsn.category == "task-planning" for lsn in report.lessons)
+        # Critical planning lesson is surfaced when consulting a similar task
+        relevant = analyzer.consult_before_task("Migrate the database, wrong order risk")
+        assert len(relevant) >= 1
+        assert any(lsn.severity == "critical" for lsn in relevant)
+
+    def test_security_session(self, tmp_path):
+        _install_fake_ollama(_make_fake_ollama_pairs(("hardcoded", LLM_RESPONSE_SECURITY)))
+        try:
+            analyzer = ReflectionAnalyzer(storage_path=str(tmp_path / "lessons.json"))
+            report = analyzer.analyze("int-sec", CONVERSATION_SECURITY)
+        finally:
+            _install_fake_ollama(None)
+
+        assert report.source == "llm"
+        assert report.went_well == []
+        assert any("password" in w for w in report.went_wrong)
+        assert len(report.lessons) == 1
+        lesson = report.lessons[0]
+        assert lesson.category == "security"
+        assert lesson.severity == "critical"
+        relevant = analyzer.consult_before_task("Fix an unauthorized data exposure")
+        assert any(lsn.id == lesson.id for lsn in relevant)
+
+    def test_markdown_fenced_json_is_stripped(self, tmp_path):
+        fenced = "```json\n" + LLM_RESPONSE_DEBUGGING + "\n```"
+        _install_fake_ollama(_make_fake_ollama_pairs(("/v1/checkout", fenced)))
+        try:
+            analyzer = ReflectionAnalyzer(storage_path=str(tmp_path / "lessons.json"))
+            report = analyzer.analyze("int-fenced", CONVERSATION_DEBUGGING)
+        finally:
+            _install_fake_ollama(None)
+
+        assert report.source == "llm"
+        assert len(report.lessons) == 1
+
+    def test_malformed_llm_json_falls_back(self, tmp_path):
+        _install_fake_ollama(_make_fake_ollama_pairs(("/v1/checkout", "I cannot answer that.")))
+        try:
+            analyzer = ReflectionAnalyzer(storage_path=str(tmp_path / "lessons.json"))
+            report = analyzer.analyze("int-bad-json", CONVERSATION_DEBUGGING)
+        finally:
+            _install_fake_ollama(None)
+
+        assert report.source == "fallback"
+        # Fallback is still content-based: it found the failure text
+        assert any("/v1/checkout" in w for w in report.went_wrong)
+        assert len(report.lessons) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Fallback tests (deterministic, no Ollama)
+# ---------------------------------------------------------------------------
+
+
+class TestReflectionFallback:
+    def test_ollama_connection_failure_uses_fallback(self, no_ollama, tmp_path):
+        # No fake module and no real Ollama dependency path: the client is
+        # pointed at an unused port so any importable ollama would fail too.
+        analyzer = ReflectionAnalyzer(
+            storage_path=str(tmp_path / "lessons.json"),
+            llm_base_url="http://127.0.0.1:1",
+            llm_timeout=1.0,
+        )
+        report = analyzer.analyze("int-offline", CONVERSATION_DEBUGGING)
+        assert report.source == "fallback"
+        assert any("/v1/checkout" in w for w in report.went_wrong)
+        assert len(report.went_wrong) >= 1
+        assert len(report.lessons) >= 1
+        # Fallback summarizes the most important N messages
+        assert report.went_well or report.went_wrong or report.missing_info
+
+    def test_fallback_content_based_summary(self, no_ollama, tmp_path):
+        analyzer = ReflectionAnalyzer(
+            storage_path=str(tmp_path / "lessons.json"), fallback_top_n=3
+        )
+        report = analyzer.analyze("int-fb", CONVERSATION_PLANNING)
+        assert report.source == "fallback"
+        # The important failure messages are surfaced, not just metadata
+        assert any("wrong order" in w for w in report.went_wrong)
+        assert any("missed step 3" in w for w in report.went_wrong)
+        assert any(lsn.category == "task-planning" for lsn in report.lessons)
+        assert any(lsn.severity == "warning" for lsn in report.lessons)
+
+    def test_neutral_conversation_still_summarized(self, no_ollama, tmp_path):
+        conversation = [
+            {"role": "user", "content": "What is the capital of France?"},
+            {"role": "assistant", "content": "The capital of France is Paris."},
+        ]
+        analyzer = ReflectionAnalyzer(storage_path=str(tmp_path / "lessons.json"))
+        report = analyzer.analyze("int-neutral", conversation)
+        assert report.source == "fallback"
+        # Even without keyword signals, the top messages are summarized
+        assert len(report.lessons) >= 1
+        assert any("Paris" in lsn.observation or "France" in lsn.observation for lsn in report.lessons)
+
+    def test_empty_conversation(self, no_ollama):
+        analyzer = ReflectionAnalyzer()
+        report = analyzer.analyze("int-empty", [])
+        assert report.source == "fallback"
+        assert report.went_well == []
+        assert report.went_wrong == []
+        assert report.lessons == []
+
+    def test_lesson_consumption_roundtrip(self, no_ollama, tmp_path):
+        """Lessons produced by analyze() feed consult_before_task."""
+        analyzer = ReflectionAnalyzer(storage_path=str(tmp_path / "lessons.json"))
+        analyzer.analyze("int-1", CONVERSATION_DEBUGGING)
+        relevant = analyzer.consult_before_task("Call the checkout API with this tool")
+        assert len(relevant) >= 1
+        assert all(not lsn.resolved for lsn in relevant)
+        assert all(lsn.lesson_text for lsn in relevant)
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestReflectionConfig:
+    def test_default_model_and_base_url(self):
+        analyzer = ReflectionAnalyzer()
+        assert analyzer.llm_model == "qwen3.5-9b"
+        assert analyzer.llm_base_url == "http://localhost:11434"
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_MODEL", "gemma4:31b")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://10.0.0.5:11434")
+        analyzer = ReflectionAnalyzer()
+        assert analyzer.llm_model == "gemma4:31b"
+        assert analyzer.llm_base_url == "http://10.0.0.5:11434"
+
+    def test_explicit_args_beat_env(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_MODEL", "gemma4:31b")
+        analyzer = ReflectionAnalyzer(llm_model="custom-model", llm_base_url="http://x:1")
+        assert analyzer.llm_model == "custom-model"
+        assert analyzer.llm_base_url == "http://x:1"
+
+
+# ---------------------------------------------------------------------------
+# Prompt sanity
+# ---------------------------------------------------------------------------
+
+
+class TestPrompts:
+    def test_system_prompt_documents_schema(self):
+        for key in ("went_well", "went_wrong", "missing_info", "lessons", "category", "severity"):
+            assert key in _REFLECT_SYSTEM_PROMPT
+
+    def test_user_prompt_renders_conversation(self):
+        rendered = _render_conversation(CONVERSATION_DEBUGGING)
+        assert "user" in rendered
+        assert "/v1/checkout" in rendered
+        filled = _REFLECT_USER_PROMPT.format(conversation=rendered)
+        assert "/v1/checkout" in filled
+
+    def test_render_conversation_truncates_and_skips_junk(self):
+        conversation = [
+            {"role": "user", "content": "x" * 10000},
+            {"role": "assistant", "content": ""},
+            "not-a-dict",
+            {"role": "assistant", "content": "second message"},
+        ]
+        rendered = _render_conversation(conversation, max_chars=100)
+        assert "second message" not in rendered  # truncated before it
+        assert "(truncated)" in rendered


### PR DESCRIPTION
## Sorun

Issue #126: `reflection/analyzer.py`'deki `analyze()` gerçek bir analiz yapmıyordu — sadece metadata tabanlı (kategori etiketi + severity) çıktı üretiyordu, oturum içeriğine bakmıyordu. "Ne iyi gitti / ne kötü gitti" sorusuna gerçek cevap yoktu.

## Yaklaşım

`analyze()` artık **gerçek bir Ollama LLM çağrısı** yapıyor ve oturum içeriği üzerinden yapılandırılmış bir refleksiyon üretiyor:

- **LLM yolu:** `ollama.Client.chat()` (repo'daki diğer Ollama kullanımıyla aynı约定: `summarizer.py` / `decomposer.py` ile aynı desen — `host` + `timeout` + `options`). Sistem prompt'unda tam JSON şeması tanımlı; model oturum içeriğine bakıp çıktıyı üretiyor.
- **Çıktı şeması (yapılandırılmış):**
  - `went_well[]` — ne iyi gitti (içerik bazlı, somut)
  - `went_wrong[]` — ne kötü gitti (somut hatalar/adımlar/değerler)
  - `missing_info[]` — eksik/varsayılan bilgi
  - `lessons[]` — her biri: `category` (tool-use | context-management | task-planning | communication | security | general), `observation`, `lesson_text`, `severity` (info | warning | critical)
- **Güvenilir parse:** markdown code fence temizleme, JSON object extraction, kategori/severity doğrulama; parse edilemez/geçersiz çıktıda **fallback**'e düşüyor.
- **Fallback (LLM yoksa/başarısızsa/geçersizse):** metadata değil, **içerik tabanlı** — mesajlara importance skoru verip **en önemli N mesajı özetliyor** (varsayılan N=3), somut hatalar/eksiklikler/başarılar üzerinden yapılandırılmış dersler çıkarıyor. Neutral (keyword'siz) oturumlarda bile en önemli mesajlar özetleniyor.
- `ReflectionReport.source` hangi yolun raporu ürettiğini izliyor (`llm` | `fallback`).

## Config

| Parametre | Env | Varsayılan |
|---|---|---|
| `llm_model` | `OLLAMA_MODEL` | `qwen3.5-9b` |
| `llm_base_url` | `OLLAMA_BASE_URL` | `http://localhost:11434` |
| `llm_timeout` | — | `60.0` s |
| `fallback_top_n` | — | `3` |

Mevcut Ollama config'iyle aynı env约定ini kullanıyor (`OLLAMA_MODEL` / `OLLAMA_BASE_URL`).

## Geriye dönük uyumluluk

- `consult_before_task` / `record_success` / `record_failure` / persistence / `Lesson` şeması **değişmedi** — `analyze()` her iki yolda da aynı `lessons` + mistake tracking davranışını üretiyor, çağrıcılar (consult-before-task "ders" tüketimi) bozulmuyor.
- Mevcut `tests/test_reflection.py` paketi (35 test) aynen geçiyor.

## Test kapsamı

- **16 yeni test** (`tests/test_reflection_llm.py`):
  - **3+ integration test** — farklı oturum içerikleriyle (debugging/API-timeout, task-planning/wrong-order, security/exposure), **mock edilmiş Ollama client** ile deterministik (ortamda real Ollama olmasa da çalışır).
  - Malformed-JSON → fallback, bağlantı hatası → fallback, neutral oturum özetlemesi, boş oturum, lesson consumption roundtrip, config (default/env/explicit), prompt sanity (şema + render + truncation).
- Local: **pytest full suite 440 passed / 99 skipped**, `ruff check src/` temiz, `mypy src/` temiz.

Closes #126