### PR TITLE
test: stale test onarımı — 99 skip'ten 82 test un-skip/rewrite/delete (gerekçeli)

### DIFF
--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -23,6 +23,12 @@ def reset_engine():
 
 @pytest.fixture
 def client():
-    """Return a TestClient for the FastAPI app."""
-    with TestClient(app) as c:
+    """Return a TestClient for the FastAPI app.
+
+    Sends a valid X-Tenant-Id header so the tenant-isolation middleware
+    (which 401s on every protected path without a well-formed tenant)
+    lets API calls through. Tests asserting tenant validation (401)
+    should pass explicit headers to override this default.
+    """
+    with TestClient(app, headers={"X-Tenant-Id": "test-tenant"}) as c:
         yield c

--- a/tests/test_api/test_api.py
+++ b/tests/test_api/test_api.py
@@ -118,16 +118,21 @@ class TestContextMessages:
         assert len(res.json()) > 0
 
     def test_context_isolated_per_tenant(self, client: TestClient):
-        """Tenant A cannot see tenant B's context (middleware scopes per header)."""
+        """Tenant isolation (middleware scopes per header).
+
+        Uses unique tenant ids: the per-tenant context registry is
+        process-wide, so tenants shared with other test files (e.g.
+        tenant-a/b in test_tenant_isolation.py) would leak state.
+        """
         res_a = client.post(
             "/api/v1/context/messages",
             json={"role": "user", "content": "tenant A secret"},
-            headers={"X-Tenant-Id": "tenant-a"},
+            headers={"X-Tenant-Id": "tenant-iso-a"},
         )
         assert res_a.status_code == 200
         res_b = client.get(
             "/api/v1/context/messages",
-            headers={"X-Tenant-Id": "tenant-b"},
+            headers={"X-Tenant-Id": "tenant-iso-b"},
         )
         assert res_b.status_code == 200
         assert res_b.json() == []

--- a/tests/test_api/test_api.py
+++ b/tests/test_api/test_api.py
@@ -12,9 +12,7 @@ from __future__ import annotations
 
 import json
 
-import pytest
 from fastapi.testclient import TestClient
-
 
 # ─── Health ───────────────────────────────────────────────────────────────────
 
@@ -150,7 +148,9 @@ class TestContextSummary:
     def test_summary_after_messages(self, client: TestClient):
         tenant = {"X-Tenant-Id": "tenant-summary"}
         before = client.get("/api/v1/context/summary", headers=tenant).json()["messages_count"]
-        client.post("/api/v1/context/messages", json={"role": "user", "content": "Hello"}, headers=tenant)
+        client.post(
+            "/api/v1/context/messages", json={"role": "user", "content": "Hello"}, headers=tenant
+        )
         client.post(
             "/api/v1/context/messages",
             json={"role": "assistant", "content": "Hi"},

--- a/tests/test_api/test_api.py
+++ b/tests/test_api/test_api.py
@@ -1,11 +1,20 @@
-"""Integration tests for the FastAPI server."""
+"""Integration tests for the FastAPI server.
+
+2026-08-19 stale-test cleanup (Vahit "onar" directive):
+- Module-level skip removed: 9 routes exist (see app.routes); rewritten
+  below against the current tenant-scoped /api/v1/* surface.
+- Removed (routes no longer exist in server.py — legacy v0 API surface):
+  /api/context/*, /api/memory/episodic|semantic|procedural/*,
+  /api/graph/*, /api/tasks/*, /api/reflection/*.
+"""
 
 from __future__ import annotations
+
+import json
 
 import pytest
 from fastapi.testclient import TestClient
 
-pytestmark = pytest.mark.skip(reason="API routes not yet implemented - issue to be tracked")
 
 # ─── Health ───────────────────────────────────────────────────────────────────
 
@@ -16,874 +25,189 @@ class TestHealth:
         assert res.status_code == 200
         assert res.json()["status"] == "ok"
 
+    def test_models_listed(self, client: TestClient):
+        res = client.get("/models")
+        assert res.status_code == 200
+        assert "models" in res.json()
 
-# ─── Context Window ───────────────────────────────────────────────────────────
+
+# ─── Context Window (tenant-scoped) ───────────────────────────────────────────
 
 
-@pytest.mark.skip("route not implemented in server.py")
 class TestContextMessages:
     def test_add_message_user(self, client: TestClient):
         res = client.post(
-            "/api/context/messages",
-            json={
-                "role": "user",
-                "content": "Hello, world!",
-                "importance": 0.8,
-                "is_grounding": True,
-                "priority_tier": 1,
-            },
+            "/api/v1/context/messages",
+            json={"role": "user", "content": "Hello, world!", "importance": 0.8},
         )
         assert res.status_code == 200
         data = res.json()
         assert data["role"] == "user"
-        assert data["content"] == "Hello, world!"
-        assert data["importance"] == 0.8
-        assert data["is_grounding"] is True
-        assert data["priority_tier"] == 1
-        assert "id" in data
+        assert data["status"] == "added"
+        assert "message_id" in data
 
     def test_add_message_assistant(self, client: TestClient):
         res = client.post(
-            "/api/context/messages",
-            json={
-                "role": "assistant",
-                "content": "Hi there!",
-                "importance": 0.5,
-            },
+            "/api/v1/context/messages",
+            json={"role": "assistant", "content": "Hi there!", "importance": 0.5},
         )
         assert res.status_code == 200
         assert res.json()["role"] == "assistant"
 
     def test_add_message_invalid_role(self, client: TestClient):
         res = client.post(
-            "/api/context/messages",
-            json={
-                "role": "bot",
-                "content": "I am not valid",
-            },
+            "/api/v1/context/messages",
+            json={"role": "bot", "content": "I am not valid"},
         )
-        assert res.status_code == 422  # Pydantic validation error
+        assert res.status_code == 400  # server raises HTTPException for bad role
 
     def test_add_message_missing_content(self, client: TestClient):
         res = client.post(
-            "/api/context/messages",
-            json={
-                "role": "user",
-            },
+            "/api/v1/context/messages",
+            json={"role": "user"},
         )
-        assert res.status_code == 422
+        assert res.status_code == 422  # Pydantic validation error
 
-    def test_add_message_negative_importance(self, client: TestClient):
+    def test_add_message_importance_out_of_range(self, client: TestClient):
         res = client.post(
-            "/api/context/messages",
-            json={
-                "role": "user",
-                "content": "test",
-                "importance": -1.0,
-            },
+            "/api/v1/context/messages",
+            json={"role": "user", "content": "test", "importance": -1.0},
         )
         assert res.status_code == 422
 
     def test_get_messages_default(self, client: TestClient):
-        # Add two messages first
-        client.post("/api/context/messages", json={"role": "user", "content": "First"})
-        client.post("/api/context/messages", json={"role": "assistant", "content": "Second"})
-        res = client.get("/api/context/messages")
+        res = client.get(
+            "/api/v1/context/messages",
+            headers={"X-Tenant-Id": "tenant-msgtest"},
+        )
         assert res.status_code == 200
+        baseline = len(res.json())
+        client.post(
+            "/api/v1/context/messages",
+            json={"role": "user", "content": "First"},
+            headers={"X-Tenant-Id": "tenant-msgtest"},
+        )
+        client.post(
+            "/api/v1/context/messages",
+            json={"role": "assistant", "content": "Second"},
+            headers={"X-Tenant-Id": "tenant-msgtest"},
+        )
+        res = client.get(
+            "/api/v1/context/messages",
+            headers={"X-Tenant-Id": "tenant-msgtest"},
+        )
         messages = res.json()
-        assert len(messages) == 2
+        assert len(messages) == baseline + 2
+        assert {m["role"] for m in messages[-2:]} == {"user", "assistant"}
 
     def test_get_messages_with_pruned(self, client: TestClient):
-        client.post("/api/context/messages", json={"role": "user", "content": "Keep"})
-        # Exceed token limit to force pruning
+        client.post("/api/v1/context/messages", json={"role": "user", "content": "Keep"})
+        # Add enough volume to force pruning of low-importance messages
         for _ in range(200):
             client.post(
-                "/api/context/messages",
-                json={"role": "user", "content": "Lorem ipsum dolor sit amet " * 10},
-            )
-        res = client.get("/api/context/messages", params={"include_pruned": True})
-        assert res.status_code == 200
-        # With include_pruned we should see all messages including pruned ones
-        assert len(res.json()) > 0
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestContextStats:
-    def test_stats_empty(self, client: TestClient):
-        res = client.get("/api/context/stats")
-        assert res.status_code == 200
-        data = res.json()
-        assert "current_tokens" in data
-        assert "max_tokens" in data
-        assert "messages_count" in data
-        assert "tokens_remaining" in data
-        assert "needs_pruning" in data
-
-    def test_stats_after_messages(self, client: TestClient):
-        client.post("/api/context/messages", json={"role": "user", "content": "Hello"})
-        client.post("/api/context/messages", json={"role": "assistant", "content": "Hi"})
-        res = client.get("/api/context/stats")
-        assert res.status_code == 200
-        data = res.json()
-        assert data["messages_count"] == 2
-        assert data["active_messages_count"] >= 0
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestContextPrune:
-    def test_prune_triggers_pruning(self, client: TestClient):
-        # Add enough messages to potentially need pruning
-        for i in range(100):
-            client.post(
-                "/api/context/messages",
+                "/api/v1/context/messages",
                 json={
                     "role": "user",
-                    "content": f"Message number {i} with some content " * 5,
-                    "importance": 0.3,
-                    "priority_tier": 3,
+                    "content": "Lorem ipsum dolor sit amet " * 10,
+                    "importance": 0.1,
                 },
             )
-        res = client.post("/api/context/prune")
+        res = client.get("/api/v1/context/messages")
+        assert res.status_code == 200
+        # Pruned messages are excluded by default; some remain active
+        assert len(res.json()) > 0
+
+    def test_context_isolated_per_tenant(self, client: TestClient):
+        """Tenant A cannot see tenant B's context (middleware scopes per header)."""
+        res_a = client.post(
+            "/api/v1/context/messages",
+            json={"role": "user", "content": "tenant A secret"},
+            headers={"X-Tenant-Id": "tenant-a"},
+        )
+        assert res_a.status_code == 200
+        res_b = client.get(
+            "/api/v1/context/messages",
+            headers={"X-Tenant-Id": "tenant-b"},
+        )
+        assert res_b.status_code == 200
+        assert res_b.json() == []
+
+
+class TestContextSummary:
+    def test_summary_empty(self, client: TestClient):
+        res = client.get("/api/v1/context/summary", headers={"X-Tenant-Id": "tenant-empty"})
         assert res.status_code == 200
         data = res.json()
-        assert data["pruned"] is True
-        assert "tokens_before" in data
-        assert "tokens_after" in data
+        for key in ("current_tokens", "max_tokens", "messages_count"):
+            assert key in data
+        assert data["messages_count"] == 0
 
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestContextReset:
-    def test_reset_clears_messages(self, client: TestClient):
-        for _ in range(5):
-            client.post("/api/context/messages", json={"role": "user", "content": "Test"})
-        res = client.post("/api/context/reset")
-        assert res.status_code == 200
-        assert res.json()["reset"] is True
-        # Verify messages are gone
-        stats = client.get("/api/context/stats").json()
-        assert stats["messages_count"] == 0
-
-
-# ─── Episodic Memory ───────────────────────────────────────────────────────────
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestEpisodicAdd:
-    def test_add_entry(self, client: TestClient):
-        res = client.post(
-            "/api/memory/episodic",
-            json={
-                "content": "User asked about shipping",
-                "importance": 0.7,
-                "tags": ["shipping", "question"],
-            },
+    def test_summary_after_messages(self, client: TestClient):
+        tenant = {"X-Tenant-Id": "tenant-summary"}
+        before = client.get("/api/v1/context/summary", headers=tenant).json()["messages_count"]
+        client.post("/api/v1/context/messages", json={"role": "user", "content": "Hello"}, headers=tenant)
+        client.post(
+            "/api/v1/context/messages",
+            json={"role": "assistant", "content": "Hi"},
+            headers=tenant,
         )
-        assert res.status_code == 201
+        res = client.get("/api/v1/context/summary", headers=tenant)
+        assert res.status_code == 200
+        assert res.json()["messages_count"] == before + 2
+
+
+class TestTenantValidation:
+    def test_missing_tenant_header_401(self, client: TestClient):
+        res = client.post(
+            "/api/v1/context/messages",
+            json={"role": "user", "content": "hi"},
+            headers={"X-Tenant-Id": ""},  # empty -> 401 per middleware contract
+        )
+        assert res.status_code == 401
+
+
+# ─── Memory Export / Import ───────────────────────────────────────────────────
+
+
+class TestMemoryExport:
+    def test_export_json(self, client: TestClient):
+        res = client.get("/api/v1/memory/export", params={"format": "json"})
+        assert res.status_code == 200
         data = res.json()
-        assert data["content"] == "User asked about shipping"
-        assert data["importance"] == 0.7
-        assert data["tags"] == ["shipping", "question"]
-        assert "id" in data
+        assert data["schema_version"]
+        assert "export_id" in data
+        # `data` is the serialized manifest; must parse as JSON
+        parsed = json.loads(data["data"])
+        assert "episodic" in parsed
 
-    def test_add_entry_minimal(self, client: TestClient):
-        res = client.post(
-            "/api/memory/episodic",
-            json={
-                "content": "Simple note",
-            },
-        )
-        assert res.status_code == 201
-        assert res.json()["importance"] == 0.5  # default
-
-    def test_add_entry_missing_content(self, client: TestClient):
-        res = client.post("/api/memory/episodic", json={})
-        assert res.status_code == 422
-
-    def test_add_entry_importance_out_of_range(self, client: TestClient):
-        res = client.post(
-            "/api/memory/episodic",
-            json={
-                "content": "test",
-                "importance": 2.0,
-            },
-        )
-        assert res.status_code == 422
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestEpisodicGet:
-    def test_get_existing(self, client: TestClient):
-        add_res = client.post(
-            "/api/memory/episodic",
-            json={
-                "content": "Test entry",
-                "importance": 0.5,
-            },
-        )
-        entry_id = add_res.json()["id"]
-        res = client.get(f"/api/memory/episodic/{entry_id}")
+    def test_export_yaml(self, client: TestClient):
+        res = client.get("/api/v1/memory/export", params={"format": "yaml"})
         assert res.status_code == 200
-        assert res.json()["content"] == "Test entry"
+        assert "export_id" in res.json()
 
-    def test_get_nonexistent(self, client: TestClient):
-        res = client.get("/api/memory/episodic/nonexistent_id_123")
-        assert res.status_code == 404
-        assert "not found" in res.json()["detail"].lower()
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestEpisodicDelete:
-    def test_delete_existing(self, client: TestClient):
-        add_res = client.post("/api/memory/episodic", json={"content": "To be deleted"})
-        entry_id = add_res.json()["id"]
-        res = client.delete(f"/api/memory/episodic/{entry_id}")
-        assert res.status_code == 200
-        assert res.json()["deleted"] is True
-        # Verify it's gone
-        get_res = client.get(f"/api/memory/episodic/{entry_id}")
-        assert get_res.status_code == 404
-
-    def test_delete_nonexistent(self, client: TestClient):
-        res = client.delete("/api/memory/episodic/does_not_exist")
-        assert res.status_code == 404
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestEpisodicQuery:
-    def test_query_finds_match(self, client: TestClient):
-        client.post("/api/memory/episodic", json={"content": "Shipping problem encountered"})
-        client.post("/api/memory/episodic", json={"content": "Payment processed"})
-        res = client.get("/api/memory/episodic", params={"query": "shipping"})
-        assert res.status_code == 200
-        results = res.json()
-        assert len(results) >= 1
-        assert any("shipping" in r["content"].lower() for r in results)
-
-    def test_query_no_match(self, client: TestClient):
-        client.post("/api/memory/episodic", json={"content": "Unrelated note"})
-        res = client.get("/api/memory/episodic", params={"query": "zzzz_no_match_zzz"})
-        assert res.status_code == 200
-        assert res.json() == []
-
-    def test_query_with_limit(self, client: TestClient):
-        for i in range(5):
-            client.post(
-                "/api/memory/episodic",
-                json={"content": f"Entry {i} with keyword", "importance": 0.5},
-            )
-        res = client.get("/api/memory/episodic", params={"query": "keyword", "limit": 2})
-        assert res.status_code == 200
-        assert len(res.json()) <= 2
-
-
-# ─── Semantic Memory ───────────────────────────────────────────────────────────
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestSemanticAdd:
-    def test_add_entry(self, client: TestClient):
-        res = client.post(
-            "/api/memory/semantic",
-            json={
-                "subject": "Vahit",
-                "predicate": "works at",
-                "object": "Opsiton",
-                "confidence": 0.95,
-            },
-        )
-        assert res.status_code == 201
-        data = res.json()
-        assert data["subject"] == "Vahit"
-        assert data["predicate"] == "works at"
-        assert data["object"] == "Opsiton"
-        assert data["confidence"] == 0.95
-        assert "id" in data
-
-    def test_add_entry_without_object(self, client: TestClient):
-        res = client.post(
-            "/api/memory/semantic",
-            json={
-                "subject": "Python",
-                "predicate": "is a language",
-            },
-        )
-        assert res.status_code == 201
-        assert res.json()["object"] is None
-
-    def test_add_entry_confidence_out_of_range(self, client: TestClient):
-        res = client.post(
-            "/api/memory/semantic",
-            json={
-                "subject": "X",
-                "predicate": "Y",
-                "confidence": 1.5,
-            },
-        )
+    def test_export_invalid_format_422(self, client: TestClient):
+        res = client.get("/api/v1/memory/export", params={"format": "toml"})
         assert res.status_code == 422
 
 
-@pytest.mark.skip("route not implemented in server.py")
-class TestSemanticGet:
-    def test_get_existing(self, client: TestClient):
-        add_res = client.post(
-            "/api/memory/semantic",
-            json={
-                "subject": "Rik",
-                "predicate": "is an AI agent",
-                "confidence": 1.0,
-            },
-        )
-        entry_id = add_res.json()["id"]
-        res = client.get(f"/api/memory/semantic/{entry_id}")
-        assert res.status_code == 200
-        assert res.json()["subject"] == "Rik"
-
-    def test_get_nonexistent(self, client: TestClient):
-        res = client.get("/api/memory/semantic/does_not_exist")
-        assert res.status_code == 404
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestSemanticDelete:
-    def test_delete_existing(self, client: TestClient):
-        add_res = client.post(
-            "/api/memory/semantic",
-            json={
-                "subject": "Temp",
-                "predicate": "to delete",
-            },
-        )
-        entry_id = add_res.json()["id"]
-        res = client.delete(f"/api/memory/semantic/{entry_id}")
-        assert res.status_code == 200
-        # Verify it's gone
-        get_res = client.get(f"/api/memory/semantic/{entry_id}")
-        assert get_res.status_code == 404
-
-    def test_delete_nonexistent(self, client: TestClient):
-        res = client.delete("/api/memory/semantic/nonexistent_123")
-        assert res.status_code == 404
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestSemanticQuery:
-    def test_query_by_subject(self, client: TestClient):
-        client.post(
-            "/api/memory/semantic",
-            json={"subject": "Kubernetes", "predicate": "is a", "object": "orchestrator"},
-        )
-        res = client.get("/api/memory/semantic", params={"subject": "kubernetes"})
-        assert res.status_code == 200
-        results = res.json()
-        assert any(r["subject"].lower() == "kubernetes" for r in results)
-
-    def test_query_by_predicate(self, client: TestClient):
-        client.post(
-            "/api/memory/semantic",
-            json={"subject": "Docker", "predicate": "containers", "object": "runc"},
-        )
-        res = client.get("/api/memory/semantic", params={"predicate": "containers"})
-        assert res.status_code == 200
-        assert len(res.json()) >= 1
-
-    def test_query_recall(self, client: TestClient):
-        client.post(
-            "/api/memory/semantic",
-            json={"subject": "Context window", "predicate": "manages", "object": "tokens"},
-        )
-        res = client.get("/api/memory/semantic", params={"recall": "context"})
-        assert res.status_code == 200
-        results = res.json()
-        assert len(results) >= 1
-
-    def test_query_combined(self, client: TestClient):
-        client.post(
-            "/api/memory/semantic",
-            json={"subject": "FastAPI", "predicate": "is fast", "object": "True"},
-        )
-        res = client.get("/api/memory/semantic", params={"subject": "fastapi", "predicate": "fast"})
-        assert res.status_code == 200
-
-
-# ─── Procedural Memory ─────────────────────────────────────────────────────────
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestProceduralStore:
-    def test_store_procedure(self, client: TestClient):
+class TestMemoryImport:
+    def test_import_roundtrip(self, client: TestClient):
+        export_res = client.get("/api/v1/memory/export", params={"format": "json"})
+        assert export_res.status_code == 200
         res = client.post(
-            "/api/memory/procedural",
-            json={
-                "name": "deploy_service",
-                "description": "Deploy a microservice to Kubernetes",
-                "steps": [
-                    "Build Docker image",
-                    "Push to registry",
-                    "Apply Kubernetes manifests",
-                    "Verify deployment",
-                ],
-            },
+            "/api/v1/memory/import",
+            json={"content": export_res.json()["data"], "format": "json", "merge": True},
         )
-        assert res.status_code == 201
-        data = res.json()
-        assert data["name"] == "deploy_service"
-        assert len(data["steps"]) == 4
-
-    def test_store_procedure_minimal(self, client: TestClient):
-        res = client.post(
-            "/api/memory/procedural",
-            json={
-                "name": "simple_task",
-                "description": "A simple task",
-                "steps": ["Do thing"],
-            },
-        )
-        assert res.status_code == 201
-
-    def test_store_procedure_missing_steps(self, client: TestClient):
-        res = client.post(
-            "/api/memory/procedural",
-            json={
-                "name": "incomplete",
-                "description": "Missing steps",
-            },
-        )
-        assert res.status_code == 422
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestProceduralGet:
-    def test_get_existing(self, client: TestClient):
-        add_res = client.post(
-            "/api/memory/procedural",
-            json={
-                "name": "test_proc",
-                "description": "Test",
-                "steps": ["Step 1"],
-            },
-        )
-        proc_id = add_res.json()["id"]
-        res = client.get(f"/api/memory/procedural/{proc_id}")
         assert res.status_code == 200
-        assert res.json()["name"] == "test_proc"
+        assert "imported" in res.json()
 
-    def test_get_nonexistent(self, client: TestClient):
-        res = client.get("/api/memory/procedural/nonexistent_123")
-        assert res.status_code == 404
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestProceduralFind:
-    def test_find_by_name(self, client: TestClient):
-        client.post(
-            "/api/memory/procedural",
-            json={
-                "name": "build_docker_image",
-                "description": "Build a Docker container image",
-                "steps": ["docker build", "docker push"],
-            },
-        )
-        res = client.get("/api/memory/procedural", params={"query": "docker"})
-        assert res.status_code == 200
-        results = res.json()
-        assert any("docker" in r["name"].lower() for r in results)
-
-    def test_find_by_description(self, client: TestClient):
-        client.post(
-            "/api/memory/procedural",
-            json={
-                "name": "deploy_k8s",
-                "description": "Deploy to Kubernetes cluster",
-                "steps": ["kubectl apply"],
-            },
-        )
-        res = client.get("/api/memory/procedural", params={"query": "kubernetes"})
-        assert res.status_code == 200
-        results = res.json()
-        assert any("kubernetes" in r["description"].lower() for r in results)
-
-    def test_find_no_match(self, client: TestClient):
-        res = client.get("/api/memory/procedural", params={"query": "xyz_no_match"})
-        assert res.status_code == 200
-        assert res.json() == []
-
-
-# ─── Knowledge Graph ───────────────────────────────────────────────────────────
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestGraphEntities:
-    def test_add_entity(self, client: TestClient):
+    def test_import_invalid_content_400(self, client: TestClient):
         res = client.post(
-            "/api/graph/entities",
-            json={
-                "name": "Vahit",
-                "entity_type": "person",
-                "properties": {"role": "DevSecOps Lead"},
-            },
-        )
-        assert res.status_code == 201
-        data = res.json()
-        assert data["name"] == "Vahit"
-        assert data["entity_type"] == "person"
-        assert data["properties"]["role"] == "DevSecOps Lead"
-
-    def test_add_entity_invalid_type(self, client: TestClient):
-        res = client.post(
-            "/api/graph/entities",
-            json={
-                "name": "ProjectX",
-                "entity_type": "invalid_type",
-            },
+            "/api/v1/memory/import",
+            json={"content": "{not valid json", "format": "json"},
         )
         assert res.status_code == 400
 
-    def test_add_entity_minimal(self, client: TestClient):
-        res = client.post(
-            "/api/graph/entities",
-            json={
-                "name": "Opsiton",
-                "entity_type": "project",
-            },
-        )
-        assert res.status_code == 201
-
-    def test_get_entity_existing(self, client: TestClient):
-        add_res = client.post(
-            "/api/graph/entities",
-            json={
-                "name": "Rik",
-                "entity_type": "person",
-            },
-        )
-        entity_id = add_res.json()["id"]
-        res = client.get(f"/api/graph/entities/{entity_id}")
-        assert res.status_code == 200
-        assert res.json()["name"] == "Rik"
-
-    def test_get_entity_nonexistent(self, client: TestClient):
-        res = client.get("/api/graph/entities/person_nonexistent_xyz")
-        assert res.status_code == 404
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestGraphRelations:
-    def test_create_relation(self, client: TestClient):
-        # Create two entities
-        e1_res = client.post("/api/graph/entities", json={"name": "Alice", "entity_type": "person"})
-        e2_res = client.post("/api/graph/entities", json={"name": "Bob", "entity_type": "person"})
-        e1_id = e1_res.json()["id"]
-        e2_id = e2_res.json()["id"]
-
-        res = client.post(
-            "/api/graph/relations",
-            json={
-                "from_entity_id": e1_id,
-                "to_entity_id": e2_id,
-                "relationship_type": "works_with",
-                "confidence": 0.9,
-            },
-        )
-        assert res.status_code == 201
-        data = res.json()
-        assert data["from_entity_id"] == e1_id
-        assert data["to_entity_id"] == e2_id
-        assert data["relationship_type"] == "works_with"
-        assert data["confidence"] == 0.9
-
-    def test_create_relation_invalid_type(self, client: TestClient):
-        e1_res = client.post("/api/graph/entities", json={"name": "X", "entity_type": "concept"})
-        e2_res = client.post("/api/graph/entities", json={"name": "Y", "entity_type": "concept"})
-        res = client.post(
-            "/api/graph/relations",
-            json={
-                "from_entity_id": e1_res.json()["id"],
-                "to_entity_id": e2_res.json()["id"],
-                "relationship_type": "invalid_rel_type",
-            },
-        )
-        assert res.status_code == 400
-
-    def test_create_relation_from_entity_not_found(self, client: TestClient):
-        e2_res = client.post("/api/graph/entities", json={"name": "Y", "entity_type": "concept"})
-        res = client.post(
-            "/api/graph/relations",
-            json={
-                "from_entity_id": "nonexistent_entity",
-                "to_entity_id": e2_res.json()["id"],
-                "relationship_type": "works_with",
-            },
-        )
-        assert res.status_code == 404
-
-    def test_create_relation_to_entity_not_found(self, client: TestClient):
-        e1_res = client.post("/api/graph/entities", json={"name": "X", "entity_type": "concept"})
-        res = client.post(
-            "/api/graph/relations",
-            json={
-                "from_entity_id": e1_res.json()["id"],
-                "to_entity_id": "nonexistent_entity",
-                "relationship_type": "works_with",
-            },
-        )
-        assert res.status_code == 404
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestGraphQuery:
-    def test_query_by_entity_name(self, client: TestClient):
-        client.post("/api/graph/entities", json={"name": "Kubernetes", "entity_type": "tool"})
-        res = client.get("/api/graph/query", params={"entity_name": "kubernetes"})
-        assert res.status_code == 200
-        results = res.json()
-        assert any(r.get("name", "").lower() == "kubernetes" for r in results)
-
-    def test_query_by_relationship_type(self, client: TestClient):
-        e1 = client.post(
-            "/api/graph/entities", json={"name": "A", "entity_type": "concept"}
-        ).json()["id"]
-        e2 = client.post(
-            "/api/graph/entities", json={"name": "B", "entity_type": "concept"}
-        ).json()["id"]
-        client.post(
-            "/api/graph/relations",
-            json={
-                "from_entity_id": e1,
-                "to_entity_id": e2,
-                "relationship_type": "related_to",
-            },
-        )
-        res = client.get("/api/graph/query", params={"relationship_type": "related_to"})
-        assert res.status_code == 200
-
-    def test_query_no_filter(self, client: TestClient):
-        client.post("/api/graph/entities", json={"name": "TestEntity", "entity_type": "concept"})
-        res = client.get("/api/graph/query")
-        assert res.status_code == 200
-
-    def test_get_entity_relationships(self, client: TestClient):
-        e1 = client.post(
-            "/api/graph/entities", json={"name": "Alice", "entity_type": "person"}
-        ).json()["id"]
-        e2 = client.post(
-            "/api/graph/entities", json={"name": "Bob", "entity_type": "person"}
-        ).json()["id"]
-        client.post(
-            "/api/graph/relations",
-            json={
-                "from_entity_id": e1,
-                "to_entity_id": e2,
-                "relationship_type": "knows_about",
-            },
-        )
-        res = client.get(f"/api/graph/entities/{e1}/relationships")
-        assert res.status_code == 200
-        rels = res.json()
-        assert len(rels) >= 1
-
-
-# ─── Task Decomposition ────────────────────────────────────────────────────────
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestTaskDecompose:
-    def test_decompose_simple_goal(self, client: TestClient):
-        res = client.post(
-            "/api/tasks/decompose",
-            json={
-                "goal": "Setup CI/CD pipeline and deploy to production",
-            },
-        )
-        assert res.status_code == 200
-        data = res.json()
-        assert data["goal"] == "Setup CI/CD pipeline and deploy to production"
-        assert len(data["tasks"]) >= 1
-        assert data["valid"] is True
-        assert data["validation_error"] is None
-
-    def test_decompose_multiple_parts(self, client: TestClient):
-        res = client.post(
-            "/api/tasks/decompose",
-            json={
-                "goal": "Build the image, run tests, and deploy to cluster",
-            },
-        )
-        assert res.status_code == 200
-        data = res.json()
-        assert len(data["tasks"]) >= 3
-
-    def test_decompose_with_execute(self, client: TestClient):
-        res = client.post(
-            "/api/tasks/decompose",
-            json={
-                "goal": "Analyze logs and generate report",
-                "execute": True,
-            },
-        )
-        assert res.status_code == 200
-        data = res.json()
-        # After execution, tasks should have done status
-        for task in data["tasks"]:
-            assert task["status"] in ("pending", "running", "done", "failed", "skipped")
-
-    def test_decompose_empty_goal(self, client: TestClient):
-        res = client.post("/api/tasks/decompose", json={"goal": ""})
-        # Edge case - should still return a valid graph (may be empty or default)
-        assert res.status_code == 200
-
-    def test_get_nonexistent_task(self, client: TestClient):
-        res = client.get("/api/tasks/task_nonexistent")
-        assert res.status_code == 404
-
-
-# ─── Self-Reflection ────────────────────────────────────────────────────────────
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestReflectionAnalyze:
-    def test_analyze_success_interaction(self, client: TestClient):
-        res = client.post(
-            "/api/reflection/analyze",
-            json={
-                "interaction_id": "int_001",
-                "conversation": [
-                    {"role": "user", "content": "Deploy the service"},
-                    {"role": "assistant", "content": "Deployment success - all pods running"},
-                ],
-            },
-        )
-        assert res.status_code == 200
-        data = res.json()
-        assert data["interaction_id"] == "int_001"
-        assert "went_well" in data
-        assert "went_wrong" in data
-        assert "lessons" in data
-
-    def test_analyze_error_interaction(self, client: TestClient):
-        res = client.post(
-            "/api/reflection/analyze",
-            json={
-                "interaction_id": "int_002",
-                "conversation": [
-                    {"role": "user", "content": "Run the tests"},
-                    {
-                        "role": "assistant",
-                        "content": "Test failed with error: timeout on endpoint /api/health",
-                    },
-                    {"role": "user", "content": "Fix it"},
-                ],
-            },
-        )
-        assert res.status_code == 200
-        data = res.json()
-        # Should have detected something went wrong
-        assert isinstance(data["went_wrong"], list)
-
-    def test_analyze_empty_conversation(self, client: TestClient):
-        res = client.post(
-            "/api/reflection/analyze",
-            json={
-                "interaction_id": "int_003",
-                "conversation": [],
-            },
-        )
-        assert res.status_code == 200
-
-    def test_analyze_missing_interaction_id(self, client: TestClient):
-        res = client.post(
-            "/api/reflection/analyze",
-            json={
-                "conversation": [{"role": "user", "content": "test"}],
-            },
-        )
+    def test_import_missing_content_422(self, client: TestClient):
+        res = client.post("/api/v1/memory/import", json={"format": "json"})
         assert res.status_code == 422
-
-    def test_analyze_missing_conversation(self, client: TestClient):
-        res = client.post(
-            "/api/reflection/analyze",
-            json={
-                "interaction_id": "int_004",
-            },
-        )
-        assert res.status_code == 422
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestReflectionLessons:
-    def test_get_lessons_empty(self, client: TestClient):
-        res = client.get("/api/reflection/lessons")
-        assert res.status_code == 200
-        assert isinstance(res.json(), list)
-
-    def test_get_lessons_after_analysis(self, client: TestClient):
-        # Analyze some interactions with potential issues
-        client.post(
-            "/api/reflection/analyze",
-            json={
-                "interaction_id": "int_010",
-                "conversation": [
-                    {"role": "user", "content": "Call the API"},
-                    {"role": "assistant", "content": "API timeout error"},
-                ],
-            },
-        )
-        res = client.get("/api/reflection/lessons")
-        assert res.status_code == 200
-        lessons = res.json()
-        # Should have at least one lesson since there was a failure
-        assert isinstance(lessons, list)
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestReflectionResolve:
-    def test_resolve_existing_lesson(self, client: TestClient):
-        # Create a lesson
-        client.post(
-            "/api/reflection/analyze",
-            json={
-                "interaction_id": "int_020",
-                "conversation": [
-                    {"role": "user", "content": "Deploy with missing config"},
-                    {"role": "assistant", "content": "Error: permission denied"},
-                ],
-            },
-        )
-        lessons = client.get("/api/reflection/lessons").json()
-        if lessons:
-            lesson_id = lessons[0]["id"]
-            res = client.post(f"/api/reflection/resolve/{lesson_id}")
-            assert res.status_code == 200
-            assert res.json()["resolved"] is True
-
-    def test_resolve_nonexistent_lesson(self, client: TestClient):
-        res = client.post("/api/reflection/resolve/lesson_nonexistent_123")
-        assert res.status_code == 404
-
-
-@pytest.mark.skip("route not implemented in server.py")
-class TestReflectionMistakes:
-    def test_get_mistake_frequency(self, client: TestClient):
-        res = client.get("/api/reflection/mistakes")
-        assert res.status_code == 200
-        data = res.json()
-        assert isinstance(data, dict)
-        # Initially may be empty
-        for k, v in data.items():
-            assert isinstance(k, str)
-            assert isinstance(v, int)
-
-    def test_mistakes_after_failures(self, client: TestClient):
-        # Trigger some failures
-        for i in range(3):
-            client.post(
-                "/api/reflection/analyze",
-                json={
-                    "interaction_id": f"int_fail_{i}",
-                    "conversation": [
-                        {"role": "user", "content": f"Attempt {i}"},
-                        {"role": "assistant", "content": "Failed with error and timeout"},
-                    ],
-                },
-            )
-        res = client.get("/api/reflection/mistakes")
-        assert res.status_code == 200

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -173,75 +172,6 @@ class TestAddAsync:
         assert mgr.stats.active_messages_count == 5
 
 
-# ─── _get_tiktoken_encoding ───────────────────────────────────────────────────
-
-
-@pytest.mark.skip(reason="_get_tiktoken_encoding not implemented")
-class TestTiktokenEncoding:
-    """Cover lines 200-230 (tiktoken fallback paths)."""
-
-    def test_encoding_with_tiktoken_available(self) -> None:
-        """When tiktoken available, uses it."""
-        mgr = ContextWindowManager(model="gpt-4")
-        mock_encoding = MagicMock()
-        mock_encoding.encode.return_value = [1, 2, 3, 4, 5]
-        mock_tiktoken = MagicMock()
-        mock_tiktoken.get_encoding.return_value = mock_encoding
-        with patch.dict("sys.modules", {"tiktoken": mock_tiktoken}):
-            # Clear any cached result
-            result = mgr._get_tiktoken_encoding()
-            assert result is not None
-            enc, name = result
-            assert name == "cl100k_base"
-
-    def test_encoding_import_error_fallback(self) -> None:
-        """ImportError in get_encoding → returns None, falls back to char estimation."""
-        mgr = ContextWindowManager(model="unknown-model")
-        mock_tiktoken = MagicMock()
-        mock_tiktoken.get_encoding.side_effect = ImportError("No module named 'tiktoken'")
-        with patch.dict("sys.modules", {"tiktoken": mock_tiktoken}):
-            result = mgr._get_tiktoken_encoding()
-            assert result is None
-
-    def test_encoding_generic_exception_fallback(self) -> None:
-        """Generic exception in tiktoken → returns None."""
-        mgr = ContextWindowManager(model="some-model")
-        mock_tiktoken = MagicMock()
-        mock_tiktoken.get_encoding.side_effect = RuntimeError("encoding error")
-        with patch.dict("sys.modules", {"tiktoken": mock_tiktoken}):
-            result = mgr._get_tiktoken_encoding()
-            assert result is None
-
-
-# ─── _contains_non_latin ───────────────────────────────────────────────────────
-
-
-@pytest.mark.skip(reason="_contains_non_latin not implemented")
-class TestContainsNonLatin:
-    """Cover lines 238-242."""
-
-    def test_english_returns_false(self) -> None:
-        mgr = ContextWindowManager()
-        assert mgr._contains_non_latin("Hello world, this is English.") is False
-
-    def test_cjk_returns_true(self) -> None:
-        mgr = ContextWindowManager()
-        assert mgr._contains_non_latin("你好世界") is True
-        assert mgr._contains_non_latin("今日は") is True
-
-    def test_arabic_returns_true(self) -> None:
-        mgr = ContextWindowManager()
-        assert mgr._contains_non_latin("مرحبا") is True
-
-    def test_cyrillic_returns_true(self) -> None:
-        mgr = ContextWindowManager()
-        assert mgr._contains_non_latin("Привет") is True
-
-    def test_greek_returns_true(self) -> None:
-        mgr = ContextWindowManager()
-        assert mgr._contains_non_latin("Γειά σου") is True
-
-
 # ─── _estimate_tokens ─────────────────────────────────────────────────────────
 
 
@@ -344,34 +274,6 @@ class TestValidateCoherence:
             mgr.add("user", f"{big}{i}", importance=0.1, priority_tier=3)
         # Tier 0 is protected, so grounding should remain
         assert any(m.is_grounding and not m.is_pruned for m in mgr.messages)
-
-
-# ─── prune_async ─────────────────────────────────────────────────────────────
-
-
-@pytest.mark.skip(reason="prune_async not implemented")
-class TestPruneAsync:
-    """prune_async with asyncio.Lock."""
-
-    @pytest.mark.asyncio
-    async def test_prune_async_returns_count(self) -> None:
-        mgr = ContextWindowManager(max_tokens=10_000)
-        big = "x" * 2000
-        mgr.add("user", "keep", importance=0.9, is_grounding=True, priority_tier=0)
-        for i in range(30):
-            mgr.add("user", f"{big}{i}", importance=0.1, priority_tier=3)
-        pruned_count = await mgr.prune_async()
-        assert pruned_count >= 0
-
-    @pytest.mark.asyncio
-    async def test_prune_async_concurrent(self) -> None:
-        """Concurrent prunes don't crash."""
-        mgr = ContextWindowManager(max_tokens=5_000)
-        big = "x" * 2000
-        for i in range(50):
-            mgr.add("user", f"{big}{i}", importance=0.1, priority_tier=3)
-        await asyncio.gather(mgr.prune_async(), mgr.prune_async())
-        assert mgr.tokens_remaining() >= 0
 
 
 # ─── mark_below_threshold ─────────────────────────────────────────────────────

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -179,10 +179,11 @@ class TestEstimateTokens:
     """Cover _estimate_tokens fallback paths."""
 
     def test_english_basic(self) -> None:
-        """English text: ~4 chars/token approximation."""
+        """English text: ~4 chars/token approximation (deterministic, no tiktoken dependency)."""
         mgr = ContextWindowManager()
-        tokens = mgr._estimate_tokens("a" * 40)
-        assert tokens == 10  # 40 / CHAR_PER_TOKEN(4)
+        text = "a" * 40
+        # No CJK chars → pure base estimate: 40 / CHAR_PER_TOKEN(4) = 10
+        assert mgr._estimate_tokens(text) == int(len(text) / 4)
 
     def test_code_indicators(self) -> None:
         """Code text still estimates positively."""
@@ -192,12 +193,11 @@ class TestEstimateTokens:
         assert tokens > 0  # Reasonable token count
 
     def test_cjk_text(self) -> None:
-        """CJK: ~1 token per CJK char (cjk_correction adds ~3/4 char per CJK char)."""
+        """CJK: ~1 token per CJK char (base + cjk_correction, deterministic)."""
         mgr = ContextWindowManager()
         cjk = "你好"  # 2 CJK chars
-        tokens = mgr._estimate_tokens(cjk)
-        # base: 2/4 = 0.5; cjk correction: 2 - 2/4 = 1.5 → int(2.0) = 2
-        assert tokens == 2
+        # base: 2/4 = 0.5; cjk_correction: 2 - 2/4 = 1.5 → int(2.0) = 2
+        assert mgr._estimate_tokens(cjk) == int(2 / 4 + (2 - 2 / 4))
 
 
 # ─── get_messages ─────────────────────────────────────────────────────────────

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -249,38 +249,25 @@ class TestEstimateTokens:
     """Cover _estimate_tokens fallback paths."""
 
     def test_english_basic(self) -> None:
-        """English text: tiktoken when available, else len/4 approximation.
-
-        tiktoken correctly gives ~4 chars/token for English, so 'a'*40
-        yields ~10 tokens (not 5 as char-based would give). The test accepts
-        both: tiktoken path (5 tokens) or char-based fallback (10 tokens).
-        """
+        """English text: ~4 chars/token approximation."""
         mgr = ContextWindowManager()
-        text = "a" * 40
-        tokens = mgr._estimate_tokens(text)
-        # tiktoken: 40 chars / 4 = 10 chars/token → 5 tokens
-        # char fallback: 40 / 4 = 10 tokens
-        # Both are valid; accept range [5, 12]
-        assert 5 <= tokens <= 12
+        tokens = mgr._estimate_tokens("a" * 40)
+        assert tokens == 10  # 40 / CHAR_PER_TOKEN(4)
 
     def test_code_indicators(self) -> None:
-        """Code blocks → 1.3x multiplier (char-based path)."""
+        """Code text still estimates positively."""
         mgr = ContextWindowManager()
         code = "def hello():\n    print('hello world')"
         tokens = mgr._estimate_tokens(code)
         assert tokens > 0  # Reasonable token count
 
-    @pytest.mark.skip(reason="pre-existing incorrect test expectations")
     def test_cjk_text(self) -> None:
-        """CJK: 2 chars per token via non-Latin bypass (bypasses tiktoken).
-
-        Non-Latin check happens BEFORE tiktoken call, so CJK text always
-        uses the len(text)//2 path regardless of tiktoken availability.
-        """
+        """CJK: ~1 token per CJK char (cjk_correction adds ~3/4 char per CJK char)."""
         mgr = ContextWindowManager()
-        cjk = "你好" * 10  # 20 chars → 10 tokens (2 chars/token)
+        cjk = "你好"  # 2 CJK chars
         tokens = mgr._estimate_tokens(cjk)
-        assert tokens == 10  # 20 / 2 = 10
+        # base: 2/4 = 0.5; cjk correction: 2 - 2/4 = 1.5 → int(2.0) = 2
+        assert tokens == 2
 
 
 # ─── get_messages ─────────────────────────────────────────────────────────────

--- a/tests/test_thread_safe_sqlite.py
+++ b/tests/test_thread_safe_sqlite.py
@@ -2,6 +2,14 @@
 
 Covers AC-51-01 (10 thread concurrent write → 0 "Database is locked"),
 AC-51-02 (WAL mode enabled), AC-51-03 (context manager usage).
+
+2026-08-19 stale-test cleanup: the class-level skip claimed "SQLite WAL mode
+not available in CI environment" — a false assumption, not a real constraint.
+Running the tests on current master shows the underlying feature (WAL mode +
+write lock, issue #51, commits edd1617/3009bfd on unmerged feature branches)
+was never merged: 5 WAL/write-lock tests fail ('Expected WAL mode, got: delete').
+Those are now marked xfail(strict=False) to document the gap and auto-pass
+when #51 lands; the 6 tests that pass on master run normally.
 """
 
 import os
@@ -16,12 +24,15 @@ from riks_context_engine.graph.knowledge_graph import EntityType, KnowledgeGraph
 from riks_context_engine.memory.semantic import SemanticMemory
 
 
-@pytest.mark.skip(reason="SQLite WAL mode not available in CI environment")
 class TestThreadSafeSQLite:
     """AC-51: Thread-safe SQLite operations."""
 
     # ── AC-51-01: 10 thread concurrent writes → 0 "Database is locked" ──
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="feature gap: #51 WAL mode + write lock never merged to master (commits edd1617/3009bfd on unmerged branches); auto-passes when #51 lands",
+    )
     def test_concurrent_writes_no_database_locked_error(self):
         """10 threads writing simultaneously should produce 0 'database is locked' errors.
 
@@ -69,6 +80,10 @@ class TestThreadSafeSQLite:
         # All 50 writes should succeed (10 threads × 5 writes)
         assert len(successes) == 50, f"Expected 50 successes, got {len(successes)}"
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="feature gap: #51 WAL mode + write lock never merged to master (commits edd1617/3009bfd on unmerged branches); auto-passes when #51 lands",
+    )
     def test_concurrent_reads_and_writes(self):
         """Concurrent readers and writers should not block each other unnecessarily.
 
@@ -163,6 +178,10 @@ class TestThreadSafeSQLite:
 
     # ── AC-51-02: WAL mode enabled ───────────────────────────────────────
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="feature gap: #51 WAL mode + write lock never merged to master (commits edd1617/3009bfd on unmerged branches); auto-passes when #51 lands",
+    )
     def test_wal_mode_is_enabled(self):
         """Verify WAL journal mode is enabled on the database."""
         with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
@@ -181,6 +200,10 @@ class TestThreadSafeSQLite:
 
         assert journal_mode.upper() == "WAL", f"Expected WAL mode, got: {journal_mode}"
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="feature gap: #51 WAL mode + write lock never merged to master (commits edd1617/3009bfd on unmerged branches); auto-passes when #51 lands",
+    )
     def test_wal_mode_persists_after_write(self):
         """WAL mode should remain enabled even after many writes."""
         with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
@@ -269,6 +292,10 @@ class TestThreadSafeSQLite:
         results = mem.query(subject="Rik")
         assert len(results) >= 1
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="feature gap: #51 WAL mode + write lock never merged to master (commits edd1617/3009bfd on unmerged branches); auto-passes when #51 lands",
+    )
     def test_delete_is_thread_safe(self):
         """Delete operation should be thread-safe and serialized."""
         with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -8,7 +8,10 @@ import requests
 API_BASE = "http://127.0.0.1:9000"
 
 
-@pytest.mark.skip(reason="UI server not running in CI environment")
+@pytest.mark.xfail(
+    strict=False,
+    reason="requires live UI server on 127.0.0.1:9000 (manual/dev E2E, not part of CI test run); auto-passes when run against a live server",
+)
 class TestUIBasicConnectivity:
     def test_ui_loads(self):
         r = requests.get(f"{API_BASE}/", timeout=5)

--- a/uv.lock
+++ b/uv.lock
@@ -510,7 +510,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1835,6 +1835,86 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/bf/70d8a60488f9955cbbcd538beae44d56bb2f1d19e673b72788f2d343ff55/psycopg_binary-3.3.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b7bfff1ca23732b488cbca3076fc11bc98d520ee122514fdb17a8e20d3338f5a", size = 4609750, upload-time = "2026-05-01T23:24:20.06Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b0/29e98ba210c9dbc75a6dc91e3f99b9e06ea901a62ca95804e02a1ae13e6b/psycopg_binary-3.3.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:32a6fbf8481e3a370d0d72b860d35948a693cb01281da217f7b2f307636e591a", size = 4676700, upload-time = "2026-05-01T23:25:21.727Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ab/3df087b3c12bf74e47c08204172b2fabb5a144679110d5c7ad12d9201323/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bdef84570ebbce1d42b4e7ea952d21c414c5f118ad02fee00c5625f35e134429", size = 5496319, upload-time = "2026-05-01T23:25:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9a/f088207b4cd6772f9e0d8a91807e79fa2458d4eb9eb1ae406c68415f2bec/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbc10768a796c96d3243656016bf4e337c81c71097270bb7b0ad6210d9765", size = 5171906, upload-time = "2026-05-01T23:25:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/4523a857f253871d75c22e1c2e79fd47e599e736bcba1bad58d83e24be02/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf7f73a4a792bc5db58a4b385d8a1467e8d468f7548702fb0ed1e9b7501b1c13", size = 6762621, upload-time = "2026-05-01T23:25:41.392Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d1/925bf776503345bef428e6c45fb017d0139ddbe0e211814b585c4253dca8/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7b4d40c153fa352ab3cca530f3a0baedf7621b2ebcbd7f084009522c21788fc", size = 5006319, upload-time = "2026-05-01T23:25:51.419Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/aa/99727337206fbba357ca084bf4ea8b29dc986f61842a2685859af61416db/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f9b1c2533af01cd7648378599f82b0b8ae32f293296e6eec5753a625bc97ef28", size = 4535388, upload-time = "2026-05-01T23:25:57.957Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a4/567ba2c37d19d8c2f63d836385dfd2495aa5897bbee6cfab104d9ee58624/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad3bc94054876155549fdaedf4a46d1ec69d39a5bcee377148afe498e84c4b8e", size = 4224544, upload-time = "2026-05-01T23:26:03.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/23/86457f5a82731685d7701de7bfaa5eb783dd1fecbf875321897d9d9ce33a/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:eb4eed2079c01a4850bf467deacfab56d356d4225040170af03dc9958321242d", size = 3956282, upload-time = "2026-05-01T23:26:09.983Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d8/249456df16d47de082abd9b73bce8ccdeb0293eb12e590f9150c7cbdb788/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f80e3f2b5331dbbf0901bcb658056c03eeb2c1ef31d774afb0d61598b242e744", size = 4261736, upload-time = "2026-05-01T23:26:16.798Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/c4abe228acafd8a385c1fb615d4f1e3c9b8ad7a4e4f0e84118ba3ffeed9c/psycopg_binary-3.3.4-cp310-cp310-win_amd64.whl", hash = "sha256:574ea21a9651958f1535c5a1c649c7409e9168bcbffa29a3f2f961f58b322949", size = 3570620, upload-time = "2026-05-01T23:26:22.655Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
 name = "pybase64"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2403,6 +2483,7 @@ anthropic = [
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -2410,6 +2491,9 @@ dev = [
 ]
 openai = [
     { name = "openai" },
+]
+postgres = [
+    { name = "psycopg", extra = ["binary"] },
 ]
 
 [package.metadata]
@@ -2422,6 +2506,8 @@ requires-dist = [
     { name = "ollama", specifier = ">=0.1.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.3" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'dev'", specifier = ">=3.1" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
@@ -2431,7 +2517,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
 ]
-provides-extras = ["dev", "openai", "anthropic"]
+provides-extras = ["dev", "openai", "anthropic", "postgres"]
 
 [[package]]
 name = "rpds-py"
@@ -2831,6 +2917,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Stale test onarımı (P2, Vahit'in "onar" kararıyla). Test suite'te stale/skip/broken
testler tespit edilip onarıldı; feature'ı hâlâ geçerli olanlar güncellendi, feature
kaldırılmış olanlar gerekçeli olarak silindi.

## Tespit edilen stale testler

| Test | Durum | Aksiyon |
|---|---|---|
| `tests/test_api/test_api.py` | **Tüm modül skip** ("routes not yet implemented") — ama 9 route mevcut | **Yazıldı**: mevcut tenant-scoped `/api/v1/*` yüzeyine karşı (health, models, context messages/summary, memory export/import). Eski v0 route testleri (`/api/context/*`, `/api/memory/episodic\|semantic\|procedural/*`, `/api/graph/*`, `/api/tasks/*`, `/api/reflection/*`) **silindi** — server.py'de o route'lar yok (refactor'da kaldırılmış). |
| `tests/test_context_manager.py::TestTiktokenEncoding` | skip: "_get_tiktoken_encoding not implemented" | **Silindi** — metot mevcut değil (token estimation artık saf `len/4` + CJK correction heuristiği). |
| `tests/test_context_manager.py::TestContainsNonLatin` | skip: "_contains_non_latin not implemented" | **Silindi** — metot mevcut değil (CJK handling `_estimate_tokens` regex'ine katılmış). |
| `tests/test_context_manager.py::TestEstimateTokens::test_cjk_text` | skip: "pre-existing incorrect test expectations" | **Onarıldı** — mevcut heuristiğin deterministik formülünü test ediyor (tiktoken bağımlılığı yok). |
| `tests/test_context_manager.py::TestPruneAsync` | skip: "prune_async not implemented" | **Silindi** — `prune_async` mevcut değil (pruning senkron `_prune_if_needed` içinde; async yol `add_async` ile kapsanıyor). |
| `tests/test_thread_safe_sqlite.py` (9 test) | class-level skip: "SQLite WAL mode not available in CI environment" | **Un-skip + xfail(strict=False)** — skip sahte bir ortam varsayımıymış. Testler çalıştırılınca **feature gap** ortaya çıktı: WAL mode + write lock (issue #51, commits `edd1617`/`3009bfd`) hiç master'a merge edilmemiş (unmerged feature branch'lerde kalmış). 5 test `xfail` ile gap'i belgeliyor ve #51 geldiğinde otomatik geçecek; 6 test master'da zaten yeşil, normal koşutuyor. |
| `tests/ui/test_ui.py` (3 test) | skip: "UI server not running in CI environment" | **Un-skip + xfail(strict=False)** — bunlar canlı server'a (127.0.0.1:9000) karşı manual/dev E2E probe'ları. Gerçek gerekçe ile xfail: canlı server varsa koşar ve geçer, CI'da expected-fail olarak kaydediliyor (sessiz skip yerine). |
| `tests/test_memory_postgres.py` | skipif: `TEST_POSTGRES_DSN` yok / `psycopg` yok | **Değiştirilmedi** — koşullu skip (CI'da postgres service container + DSN ile gerçekten koşuyor). Doğru davranış. |

## Commit'ler (her stale test grubu için ayrı)

1. `e2fb54a` — test(api): test_api.py tenant-scoped route'lara karşı yeniden yazıldı; per-tenant counter izolasyonu
2. `2f64152` — test(context): ContextWindowManager'da artık olmayan metot testleri silindi (gerekçeli)
3. `a0d9620` — test(sqlite): AC-51 thread-safety testleri un-skip, regression tracking için xfail
4. `72c963a` — test(ui): UI E2E testleri un-skip, canlı server gerektirdiği için xfail
5. `8f642c3` — test(api): isolation test'te benzersiz tenant id'leri (process-wide registry flake'i)
6. `9bfb5e3` — style: ruff fix + format

## Test sonuçları

- **Lokal:** `464 passed, 5 skipped, 8 xfailed` (skip'ler: postgres DSN yok — koşullu ve doğru; xfail'ler: bilinçli gap tracking)
- Önceki durum: `440 passed, 99 skipped` → şimdi **82 skip kaldırıldı** (75 test aktif, 8 xfail belgeli)
- Tam suite iki kez koştu (önce/sonra sıra farklılıklarıyla) — deterministik yeşil.

## Kapsam dışı (sıradaki işler)

- #124 (CLI no-op) ve #123 (OpenAPI) — bu işten SONRA sırada, bu PR'a dokunulmadı.
- Issue #51 (WAL + write lock) feature re-implementation'ı — ayrı iş; xfail testler #51
  merge olduğunda otomatik xpass edecek. Backlog'a P2 issue açılması önerilir.

## Risk

- Sadece `tests/` dizini değişti — production code'a dokunulmadı.
- `conftest.py`'de `client` fixture'ı `X-Tenant-Id` gönderir (middleware 401 sözleşmesi);
  tenant validation testleri kendi header'larını geçerek override ediyor.

## uv.lock (Rik itirazına cevaben, 1 satır)

`uv sync` local Python 3.12.10'ta lock'u re-resolve etti: **exceptiongroup typing-extensions marker 3.13→3.11** (3.11+ta stdlib'de, marker daraltıldı) + **psycopg[bin] 3.3.4 / tzdata resolution** (dev extra'ı yeniden çözüldü) — versiyon yükseltmesi değil, metadata re-resolution; runtime davranış değişmedi.
