### PR TITLE
feat(cli): context stats/prune/clear + task queue + reflect gerçek store'lara bağlandı (#124 turn 2)

### DIFF
--- a/src/riks_context_engine/cli/main.py
+++ b/src/riks_context_engine/cli/main.py
@@ -2,9 +2,8 @@
 
 #124: `riks memory add/query` (turn 1) and `riks context stats/prune/clear`,
 `riks task <goal>`, `riks reflect --session <id>` (turn 2) are implemented
-against the real stores. `task --execute` does not execute this turn (real
-execution is the next turn after the task model is clarified); it reports
-that honestly.
+against the real stores. `riks task <goal>` queues the goal; real execution
+is intentionally out of scope until the task model is clarified.
 """
 
 from __future__ import annotations
@@ -308,8 +307,6 @@ def cmd_task(args: argparse.Namespace) -> int:
     queue = TaskQueue()
     task = queue.add(args.goal.strip())
     print(f"task queued: {task.id} ({task.status})")
-    if args.execute:
-        print("note: task queued (not yet executed) — real execution lands in a future release")
     return 0
 
 
@@ -406,9 +403,6 @@ def _build_parser() -> argparse.ArgumentParser:
     # Task commands
     task = sub.add_parser("task", help="Task operations")
     task.add_argument("goal", type=str, nargs="?", default=None, help="Goal to queue")
-    task.add_argument(
-        "--execute", action="store_true", help="Reserved: real execution lands next turn"
-    )
     task.add_argument("--list", action="store_true", help="List queued tasks")
 
     # Reflection commands
@@ -455,6 +449,10 @@ def main(argv: list[str] | None = None) -> int:
             )
         return 1
 
+    if extras:
+        print(f"error: unexpected argument(s): {' '.join(extras)}", file=sys.stderr)
+        return 2
+
     if args.command == "context":
         if args.action == "stats":
             return cmd_context_stats()
@@ -468,10 +466,6 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "reflect":
         return cmd_reflect(args)
-
-    if extras:
-        print(f"error: unexpected argument(s): {' '.join(extras)}", file=sys.stderr)
-        return 2
 
     print(f"not implemented yet: riks {args.command} {getattr(args, 'action', '') or ''}".strip())
     return 1

--- a/src/riks_context_engine/cli/main.py
+++ b/src/riks_context_engine/cli/main.py
@@ -1,16 +1,23 @@
 """Command-line interface for Rik's Context Engine.
 
-#124 (turn 1): `riks memory add` and `riks memory query` are implemented
-against the real memory stores. Other commands report "not implemented yet"
-with exit code 1 instead of the old fake "Command executed successfully".
+#124: `riks memory add/query` (turn 1) and `riks context stats/prune/clear`,
+`riks task <goal>`, `riks reflect --session <id>` (turn 2) are implemented
+against the real stores. `task --execute` does not execute this turn (real
+execution is the next turn after the task model is clarified); it reports
+that honestly.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
+from pathlib import Path
 from typing import Any
+
+from riks_context_engine.cli.task_queue import TaskQueue
+from riks_context_engine.context.manager import ContextWindowManager
 
 
 # CLI storage locations — overridable via env for tests and deployments.
@@ -217,6 +224,153 @@ def cmd_memory_query(args: argparse.Namespace, text: str | None) -> int:
     return 0
 
 
+def _context_manager_for_tenant() -> ContextWindowManager:
+    """Tenant-scoped context window manager on the shared data dir."""
+    data_dir = os.environ.get("RIKS_DATA_DIR", "data")
+    tenant = os.environ.get("RIKS_TENANT_ID", "").strip()
+    path = (
+        os.path.join(data_dir, "tenants", tenant, "context.json")
+        if tenant
+        else os.path.join(data_dir, "context.json")
+    )
+    manager = ContextWindowManager(storage_path=path)
+    manager.load()
+    return manager
+
+
+def cmd_context_stats() -> int:
+    """Report real context-window stats from the persisted store."""
+    manager = _context_manager_for_tenant()
+    s = manager.get_summary()
+    roles: dict[str, int] = {}
+    for m in manager.messages:
+        roles[m.role] = roles.get(m.role, 0) + 1
+    print(f"messages_total: {s['messages_count']}")
+    print(f"messages_active: {s['active_messages_count']}")
+    print(f"messages_pruned: {s['pruned_messages']}")
+    print(f"current_tokens: {s['current_tokens']}")
+    print(f"max_tokens: {s['max_tokens']}")
+    print(f"tokens_remaining: {s['tokens_remaining']}")
+    print(f"utilization: {s['utilization']}")
+    if roles:
+        dist = ", ".join(f"{role}={n}" for role, n in sorted(roles.items()))
+        print(f"role_distribution: {dist}")
+    return 0
+
+
+def cmd_context_prune(args: argparse.Namespace) -> int:
+    """Remove messages older than --older-than DAYS (optionally by role)."""
+    if args.older_than is None:
+        return _err("prune requires --older-than DAYS (e.g. --older-than 7)")
+    if args.older_than < 0:
+        return _err("--older-than must be >= 0")
+    manager = _context_manager_for_tenant()
+    removed = manager.prune_before(args.older_than, args.type)
+    print(f"pruned {removed} message(s) older than {args.older_than} days")
+    return 0
+
+
+def cmd_context_clear(args: argparse.Namespace) -> int:
+    """Clear all context data for the tenant (confirmation required without --yes)."""
+    if not args.yes:
+        try:
+            answer = input("Are you sure? This deletes ALL context data for this tenant. [y/N] ")
+        except EOFError:
+            answer = ""
+        if answer.strip().lower() not in ("y", "yes"):
+            print("aborted — nothing deleted (pass --yes to skip confirmation)", file=sys.stderr)
+            return 1
+    manager = _context_manager_for_tenant()
+    before = len(manager.messages)
+    manager.clear()
+    print(f"cleared {before} message(s)")
+    return 0
+
+
+def cmd_task(args: argparse.Namespace) -> int:
+    """Add a task goal to the real task queue (JSON-backed, tenant-scoped)."""
+    if args.list:
+        queue = TaskQueue()
+        tasks = queue.list()
+        if not tasks:
+            print("task queue is empty")
+            return 0
+        for t in tasks:
+            print(f"{t.id}\t{t.status}\t{t.goal}")
+        return 0
+    if args.list and args.goal:
+        return _err("use --list alone, or provide a goal to queue (not both)")
+    if not args.goal:
+        if args.list:
+            pass  # handled below
+        else:
+            return _err("task goal is required (or use --list)")
+    queue = TaskQueue()
+    task = queue.add(args.goal.strip())
+    print(f"task queued: {task.id} ({task.status})")
+    if args.execute:
+        print("note: task queued (not yet executed) — real execution lands in a future release")
+    return 0
+
+
+def cmd_reflect(args: argparse.Namespace) -> int:
+    """Reflect on a session: real analysis + lesson persistence to the store."""
+    from riks_context_engine.memory.semantic import SemanticMemory
+    from riks_context_engine.reflection.analyzer import ReflectionAnalyzer
+
+    data_dir = os.environ.get("RIKS_DATA_DIR", "data")
+    tenant = os.environ.get("RIKS_TENANT_ID", "").strip()
+    sem_path, epi_path, proc_path = _memory_store_paths()
+    semantic = SemanticMemory(db_path=sem_path)
+    lessons_path = (
+        os.path.join(data_dir, "tenants", tenant, "lessons.json")
+        if tenant
+        else os.path.join(data_dir, "lessons.json")
+    )
+    analyzer = ReflectionAnalyzer(
+        semantic_memory=semantic,
+        storage_path=lessons_path,
+        llm_base_url=os.environ.get("OLLAMA_BASE_URL"),
+        llm_model=os.environ.get("OLLAMA_MODEL"),
+    )
+
+    # Collect conversation for the session: explicit transcript file, or the
+    # persisted context window content (real store, not a mock).
+    conversation: list[dict[str, str]] = []
+    if args.transcript:
+        try:
+            raw = json.loads(Path(args.transcript).read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            return _err(f"cannot read transcript {args.transcript}: {exc}")
+        if not isinstance(raw, list) or not all(isinstance(m, dict) for m in raw):
+            return _err("transcript must be a JSON array of {role, content} objects")
+        conversation = [
+            {"role": str(m.get("role", "user")), "content": str(m.get("content", ""))} for m in raw
+        ]
+    else:
+        manager = _context_manager_for_tenant()
+        conversation = [{"role": m.role, "content": m.content} for m in manager.messages]
+
+    if not conversation:
+        return _err(
+            f"no data to reflect on for session {args.session} (context window empty and no --transcript given)"
+        )
+
+    report = analyzer.analyze(interaction_id=f"session_{args.session}", conversation=conversation)
+    analyzer.save()
+
+    print(f"reflection: session={args.session} source={report.source}")
+    if report.went_well:
+        print(f"went_well: {len(report.went_well)} item(s)")
+    if report.went_wrong:
+        print(f"went_wrong: {len(report.went_wrong)} item(s)")
+    if report.lessons:
+        print(f"lessons: {len(report.lessons)}")
+        for lesson in report.lessons:
+            print(f"  [{lesson.severity}] {lesson.category}: {lesson.lesson_text}")
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="riks",
@@ -237,15 +391,35 @@ def _build_parser() -> argparse.ArgumentParser:
     # Context commands
     ctx = sub.add_parser("context", help="Context window operations")
     ctx.add_argument("action", choices=["stats", "prune", "clear"])
+    ctx.add_argument(
+        "--type", type=str, default=None, help="prune: role filter (user/assistant/system)"
+    )
+    ctx.add_argument(
+        "--older-than",
+        type=int,
+        default=None,
+        metavar="DAYS",
+        help="prune: remove messages older than N days",
+    )
+    ctx.add_argument("--yes", action="store_true", help="clear: skip confirmation prompt")
 
     # Task commands
     task = sub.add_parser("task", help="Task operations")
-    task.add_argument("goal", type=str, help="Goal to decompose")
-    task.add_argument("--execute", action="store_true", help="Execute after decomposition")
+    task.add_argument("goal", type=str, nargs="?", default=None, help="Goal to queue")
+    task.add_argument(
+        "--execute", action="store_true", help="Reserved: real execution lands next turn"
+    )
+    task.add_argument("--list", action="store_true", help="List queued tasks")
 
     # Reflection commands
     refl = sub.add_parser("reflect", help="Self-reflection")
     refl.add_argument("--session", type=str, required=True, help="Session ID to reflect on")
+    refl.add_argument(
+        "--transcript",
+        type=str,
+        default=None,
+        help="Path to JSON transcript ([{role, content}, ...]); falls back to context window content",
+    )
     return parser
 
 
@@ -255,8 +429,8 @@ def _parse_known(argv: list[str] | None = None) -> tuple[argparse.Namespace, lis
     return parser.parse_known_args(argv)
 
 
-def main() -> int:
-    args, extras = _parse_known()
+def main(argv: list[str] | None = None) -> int:
+    args, extras = _parse_known(argv)
 
     if args.version:
         from riks_context_engine import __version__
@@ -268,14 +442,32 @@ def main() -> int:
         _build_parser().print_help()
         return 1
 
-    # memory add/query are implemented against the real memory stores (#124).
-    # memory stats and context/task/reflect remain out of scope for this turn
-    # and report that honestly instead of pretending success.
-    if args.command == "memory" and args.action in ("add", "query"):
+    # All commands are implemented against the real stores (#124).
+    if args.command == "memory":
         text = extras[0] if extras else None
         if args.action == "add":
             return cmd_memory_add(args, text, extras)
-        return cmd_memory_query(args, text)
+        if args.action == "query":
+            return cmd_memory_query(args, text)
+        if args.action == "stats":
+            return _err(
+                "not implemented yet: riks memory stats (use context stats / riks context stats)"
+            )
+        return 1
+
+    if args.command == "context":
+        if args.action == "stats":
+            return cmd_context_stats()
+        if args.action == "prune":
+            return cmd_context_prune(args)
+        if args.action == "clear":
+            return cmd_context_clear(args)
+
+    if args.command == "task":
+        return cmd_task(args)
+
+    if args.command == "reflect":
+        return cmd_reflect(args)
 
     if extras:
         print(f"error: unexpected argument(s): {' '.join(extras)}", file=sys.stderr)

--- a/src/riks_context_engine/cli/task_queue.py
+++ b/src/riks_context_engine/cli/task_queue.py
@@ -1,0 +1,92 @@
+"""CLI task queue — durable task entries (JSON-backed).
+
+`riks task <goal>` (turn 2 of #124) adds a task to the queue in a real
+store. `--execute` does NOT execute this turn (next turn implements real
+execution after the task model is clarified); it prints an honest message.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def task_queue_path() -> str:
+    data_dir = os.environ.get("RIKS_DATA_DIR", "data")
+    base = os.path.join(data_dir, os.environ.get("RIKS_TASKS_FILE", "tasks.json"))
+    tenant = os.environ.get("RIKS_TENANT_ID", "").strip()
+    if tenant:
+        base = os.path.join(data_dir, "tenants", tenant, "tasks.json")
+    return base
+
+
+@dataclass
+class QueueTask:
+    id: str
+    goal: str
+    status: str = "queued"  # queued | running | done | failed
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    executed_at: str | None = None
+    result: str | None = None
+
+
+class TaskQueue:
+    """Append-only JSON task queue, tenant-scoped like the memory stores."""
+
+    def __init__(self, path: str | None = None):
+        self.path = path or task_queue_path()
+        self._tasks: dict[str, QueueTask] = {}
+        self._load()
+
+    def _load(self) -> None:
+        p = Path(self.path)
+        if not p.exists():
+            return
+        try:
+            data = json.loads(p.read_text())
+            for d in data.get("tasks", []):
+                t = QueueTask(**d)
+                self._tasks[t.id] = t
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            pass  # start fresh on corruption
+
+    def _save(self) -> None:
+        p = Path(self.path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"tasks": [asdict(t) for t in self._tasks.values()]}, indent=2))
+
+    def add(self, goal: str) -> QueueTask:
+        task = QueueTask(id=f"task_{uuid.uuid4().hex[:8]}", goal=goal)
+        self._tasks[task.id] = task
+        self._save()
+        return task
+
+    def list(self) -> list[QueueTask]:
+        return sorted(self._tasks.values(), key=lambda t: t.created_at)
+
+    def get(self, task_id: str) -> QueueTask | None:
+        return self._tasks.get(task_id)
+
+    def mark(self, task_id: str, status: str, result: str | None = None) -> None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            raise KeyError(task_id)
+        task.status = status
+        if result is not None:
+            task.result = result
+        if status in ("done", "failed"):
+            task.executed_at = datetime.now(timezone.utc).isoformat()
+        self._save()
+
+    def count(self, status: str | None = None) -> int:
+        if status is None:
+            return len(self._tasks)
+        return sum(1 for t in self._tasks.values() if t.status == status)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"tasks": [asdict(t) for t in self.list()]}

--- a/src/riks_context_engine/context/manager.py
+++ b/src/riks_context_engine/context/manager.py
@@ -312,9 +312,34 @@ class ContextWindowManager:
         return summarizer.summarize_tier3(self, force=force)  # type: ignore[no-any-return]
 
     def clear(self) -> None:
-        """Clear all messages from context window."""
+        """Clear all messages and reset pruning stats, persisting the empty window."""
         self.messages = []
+        self._total_pruning_events = 0
         self._update_stats()
+        self._auto_save()
+
+    def prune_before(self, older_than_days: int, type_filter: str | None = None) -> int:
+        """Remove messages older than N days, optionally filtered by role.
+
+        ``type`` maps to the message role in the context window
+        (user/assistant/system). Removed messages are dropped from the active
+        window and the change is persisted.
+
+        Returns the number of removed messages.
+        """
+        cutoff = datetime.now(timezone.utc).timestamp() - older_than_days * 86400
+        kept = []
+        for m in self.messages:
+            too_old = m.timestamp.timestamp() < cutoff
+            role_match = type_filter is None or m.role == type_filter
+            if not (too_old and role_match):
+                kept.append(m)
+        removed = len(self.messages) - len(kept)
+        if removed:
+            self.messages = kept
+            self._update_stats()
+            self._auto_save()
+        return removed
 
     def mark_below_threshold(self, threshold: int = 0) -> list[ContextMessage]:
         """Return non-pruned messages whose token count is below threshold.

--- a/tests/test_cli_context_task_reflect.py
+++ b/tests/test_cli_context_task_reflect.py
@@ -1,0 +1,237 @@
+"""Integration tests for CLI turn 2 (#124): context stats/prune/clear, task, reflect.
+
+Each command is exercised against the REAL stores (tmp data dir), not mocks.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from riks_context_engine.cli.main import main
+from riks_context_engine.context.manager import ContextWindowManager
+
+
+@pytest.fixture(autouse=True)
+def isolated_data(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("RIKS_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("RIKS_TENANT_ID", raising=False)
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    return tmp_path
+
+
+def _seed_context(tmp_path: Path, backdated: int = 0) -> None:
+    mgr = ContextWindowManager(storage_path=str(tmp_path / "context.json"))
+    mgr.add("user", "fresh question", importance=0.9)
+    mgr.add("assistant", "fresh answer", importance=0.8)
+    for _ in range(backdated):
+        m = mgr.add("user", "old message", importance=0.2)
+        m.timestamp = datetime.now(timezone.utc) - timedelta(days=10)
+    mgr._auto_save()
+
+
+class TestContextStats:
+    def test_stats_empty(self, isolated_data: Path, capsys: pytest.CaptureFixture[str]):
+        rc = main(["context", "stats"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "messages_total: 0" in out
+        assert "current_tokens: 0" in out
+
+    def test_stats_with_data_and_role_distribution(
+        self, isolated_data: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        _seed_context(isolated_data, backdated=1)
+        rc = main(["context", "stats"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "messages_total: 3" in out
+        assert "user=2" in out
+        assert "assistant=1" in out
+
+    def test_stats_tenant_scoped(
+        self,
+        isolated_data: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        _seed_context(isolated_data)
+        monkeypatch.setenv("RIKS_TENANT_ID", "tenantA")
+        rc = main(["context", "stats"])
+        assert rc == 0
+        assert "messages_total: 0" in capsys.readouterr().out  # tenantB has none
+
+
+class TestContextPrune:
+    def test_prune_removes_old_messages(
+        self, isolated_data: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        _seed_context(isolated_data, backdated=2)
+        rc = main(["context", "prune", "--older-than", "7"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "pruned 2 message(s)" in out
+        # persisted state: only the 2 fresh messages remain
+        data = json.loads((isolated_data / "context.json").read_text())
+        assert len(data["messages"]) == 2
+
+    def test_prune_with_type_filter(self, isolated_data: Path, capsys: pytest.CaptureFixture[str]):
+        _seed_context(isolated_data, backdated=1)
+        rc = main(["context", "prune", "--older-than", "7", "--type", "user"])
+        assert rc == 0
+        assert "pruned 1 message(s)" in capsys.readouterr().out
+        # the old user message is gone; fresh user + fresh assistant remain
+        data = json.loads((isolated_data / "context.json").read_text())
+        assert len(data["messages"]) == 2
+
+    def test_prune_requires_older_than(
+        self, isolated_data: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        rc = main(["context", "prune"])
+        assert rc == 1
+        assert "error:" in capsys.readouterr().err
+
+    def test_prune_negative_days_rejected(
+        self, isolated_data: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        rc = main(["context", "prune", "--older-than", "-1"])
+        assert rc == 1
+
+
+class TestContextClear:
+    def test_clear_requires_confirmation(
+        self,
+        isolated_data: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        _seed_context(isolated_data)
+        monkeypatch.setattr("builtins.input", lambda *a: "n")
+        rc = main(["context", "clear"])
+        assert rc == 1
+        assert "aborted" in capsys.readouterr().err
+        data = json.loads((isolated_data / "context.json").read_text())
+        assert len(data["messages"]) == 2  # untouched
+
+    def test_clear_with_yes(self, isolated_data: Path, capsys: pytest.CaptureFixture[str]):
+        _seed_context(isolated_data, backdated=1)
+        rc = main(["context", "clear", "--yes"])
+        assert rc == 0
+        assert "cleared 3 message(s)" in capsys.readouterr().out
+        data = json.loads((isolated_data / "context.json").read_text())
+        assert len(data["messages"]) == 0
+
+    def test_clear_without_tty_aborts(self, isolated_data: Path, monkeypatch: pytest.MonkeyPatch):
+        """No --yes and no interactive input (EOF) → abort, no traceback."""
+        _seed_context(isolated_data)
+
+        def _eof(*a: Any) -> str:
+            raise EOFError
+
+        monkeypatch.setattr("builtins.input", _eof)
+        rc = main(["context", "clear"])
+        assert rc == 1
+
+
+class TestTask:
+    def test_task_add_persists(self, isolated_data: Path, capsys: pytest.CaptureFixture[str]):
+        rc = main(["task", "deploy staging"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "task queued:" in out
+        data = json.loads((isolated_data / "tasks.json").read_text())
+        assert data["tasks"][0]["goal"] == "deploy staging"
+        assert data["tasks"][0]["status"] == "queued"
+
+    def test_task_execute_is_honest(self, isolated_data: Path, capsys: pytest.CaptureFixture[str]):
+        rc = main(["task", "build pipeline", "--execute"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "task queued:" in out
+        assert "not yet executed" in out
+        data = json.loads((isolated_data / "tasks.json").read_text())
+        assert data["tasks"][0]["status"] == "queued"  # NOT executed
+
+    def test_task_list(self, isolated_data: Path, capsys: pytest.CaptureFixture[str]):
+        main(["task", "goal one"])
+        main(["task", "goal two"])
+        rc = main(["task", "--list"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "goal one" in out and "goal two" in out
+
+    def test_task_list_empty(self, isolated_data: Path, capsys: pytest.CaptureFixture[str]):
+        rc = main(["task", "--list"])
+        assert rc == 0
+        assert "empty" in capsys.readouterr().out
+
+    def test_task_requires_goal_or_list(
+        self, isolated_data: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        rc = main(["task"])
+        assert rc == 1
+        assert "error:" in capsys.readouterr().err
+
+    def test_task_tenant_scoped(self, isolated_data: Path, monkeypatch: pytest.MonkeyPatch):
+        main(["task", "shared goal"])
+        monkeypatch.setenv("RIKS_TENANT_ID", "tenantX")
+        rc = main(["task", "--list"])
+        assert rc == 0
+        # tenantX queue file (if any) must not contain the shared-tenant task
+        tenant_tasks = isolated_data / "tenants" / "tenantX" / "tasks.json"
+        if tenant_tasks.exists():
+            assert "shared goal" not in tenant_tasks.read_text()
+
+
+class TestReflect:
+    def test_reflect_with_transcript_writes_lessons(
+        self, isolated_data: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        transcript = isolated_data / "transcript.json"
+        transcript.write_text(
+            json.dumps(
+                [
+                    {"role": "user", "content": "please deploy the service"},
+                    {
+                        "role": "assistant",
+                        "content": "deploy failed: permission denied, tool error",
+                    },
+                ]
+            )
+        )
+        rc = main(["reflect", "--session", "sess-42", "--transcript", str(transcript)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "reflection: session=sess-42" in out
+        assert "lessons:" in out
+        # real persistence: lessons.json written
+        data = json.loads((isolated_data / "lessons.json").read_text())
+        assert data["lessons"], "at least one lesson must be persisted"
+
+    def test_reflect_empty_context_and_no_transcript_is_error(
+        self, isolated_data: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        rc = main(["reflect", "--session", "sess-empty"])
+        assert rc == 1
+        assert "error:" in capsys.readouterr().err
+
+    def test_reflect_from_context_window(
+        self, isolated_data: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        _seed_context(isolated_data)
+        rc = main(["reflect", "--session", "sess-ctx"])
+        assert rc == 0
+        assert "session=sess-ctx" in capsys.readouterr().out
+
+    def test_reflect_bad_transcript_is_error(
+        self, isolated_data: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        bad = isolated_data / "bad.json"
+        bad.write_text("{not json")
+        rc = main(["reflect", "--session", "s1", "--transcript", str(bad)])
+        assert rc == 1
+        assert "error:" in capsys.readouterr().err

--- a/tests/test_cli_context_task_reflect.py
+++ b/tests/test_cli_context_task_reflect.py
@@ -147,14 +147,19 @@ class TestTask:
         assert data["tasks"][0]["goal"] == "deploy staging"
         assert data["tasks"][0]["status"] == "queued"
 
-    def test_task_execute_is_honest(self, isolated_data: Path, capsys: pytest.CaptureFixture[str]):
+    def test_task_execute_flag_removed(
+        self, isolated_data: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        # #124: `--execute` was a no-op (never executed) and was removed; the
+        # task model must be clarified before real execution lands. The CLI
+        # is fail-closed about unknown options: it must refuse (exit 2), not
+        # silently queue and exit 0.
         rc = main(["task", "build pipeline", "--execute"])
-        assert rc == 0
-        out = capsys.readouterr().out
-        assert "task queued:" in out
-        assert "not yet executed" in out
-        data = json.loads((isolated_data / "tasks.json").read_text())
-        assert data["tasks"][0]["status"] == "queued"  # NOT executed
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "unexpected argument(s)" in err
+        assert "--execute" in err
+        assert not (isolated_data / "tasks.json").exists()
 
     def test_task_list(self, isolated_data: Path, capsys: pytest.CaptureFixture[str]):
         main(["task", "goal one"])

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -49,24 +49,15 @@ class TestCLI:
         assert result != 0
         assert "error:" in err
 
-    def test_main_unimplemented_commands_report_honestly(self, capsys):
-        """context/task/reflect are out of scope for #124 turn 1: they must NOT
-        pretend success — exit code 1 + 'not implemented yet'."""
-        for argv in (
-            ["riks", "memory", "stats"],
-            ["riks", "context", "stats"],
-            ["riks", "context", "prune"],
-            ["riks", "context", "clear"],
-            ["riks", "task", "test goal"],
-            ["riks", "reflect", "--session", "test-session"],
-        ):
-            sys.argv = argv
-            result = main()
-            out = capsys.readouterr()
-            combined = out.out + out.err
-            assert result == 1
-            assert "not implemented yet" in combined
-            assert "Command executed successfully" not in combined
+    def test_memory_stats_still_reports_not_implemented(self, capsys):
+        """memory stats is out of scope for #124 turn 2: must NOT pretend success."""
+        sys.argv = ["riks", "memory", "stats"]
+        result = main()
+        out = capsys.readouterr()
+        combined = out.out + out.err
+        assert result == 1
+        assert "not implemented yet" in combined
+        assert "Command executed successfully" not in combined
 
     def test_main_unknown_command_exits_with_error(self):
         """Test riks with unknown command."""

--- a/tests/test_cli_memory.py
+++ b/tests/test_cli_memory.py
@@ -157,17 +157,19 @@ class TestTenantIsolation:
 
 
 class TestNotImplemented:
-    def test_context_stats_reports_not_implemented(self, capsys):
+    def test_context_stats_is_implemented(self, tmp_path, monkeypatch, capsys):
+        """ "context stats" now returns real store data (turn 2)."""
+        monkeypatch.setenv("RIKS_DATA_DIR", str(tmp_path))
         rc = _run(["context", "stats"])
-        assert rc != 0
-        out = capsys.readouterr()
-        assert "not implemented yet" in (out.out + out.err)
+        assert rc == 0
+        assert "messages_total" in capsys.readouterr().out
 
-    def test_task_reports_not_implemented(self, capsys):
+    def test_task_is_implemented(self, tmp_path, monkeypatch, capsys):
+        """ "task <goal>" now queues into the real store (turn 2)."""
+        monkeypatch.setenv("RIKS_DATA_DIR", str(tmp_path))
         rc = _run(["task", "do something"])
-        assert rc != 0
-        out = capsys.readouterr()
-        assert "not implemented yet" in (out.out + out.err)
+        assert rc == 0
+        assert "task queued" in capsys.readouterr().out
 
     def test_fake_success_string_gone(self, capsys):
         """The old no-op printed 'Command executed successfully' — must never appear."""


### PR DESCRIPTION
## Summary

#124 turn 2: kalan CLI komutları artık gerçek store'lara bağlı. Placeholder'lar bitti — `riks` artık çalışıyor.

## Ne yapıldı

### 1. `riks context stats`
- Gerçek `ContextWindowManager` store'una bağlandı (tenant-scoped, `RIKS_DATA_DIR` + `RIKS_TENANT_ID`).
- Toplam/aktif/pruned mesaj sayısı, token istatistikleri, role dağılımı (user/assistant/system).

### 2. `riks context prune --older-than <days> [--type <role>]`
- Belirli yaşından eski entry'leri kalıcı store'dan siler; `--type` ile role filtresi.
- Silinen entry sayısı stdout'a yazılır (`pruned 2 message(s) older than 7 days`).

### 3. `riks context clear`
- `--yes` yoksa onay ister: "Are you sure? This deletes ALL context data for this tenant. [y/N]" (N/EOF → abort, exit 1).
- Onaylanınca tenant'ın tüm context verisini siler ve boş state'i kalıcı store'a yazar.

### 4. `riks task <goal>` (yeni `TaskQueue`, JSON-backed, tenant-scoped)
- Gerçek store'a entry ekleme (`tasks.json`), `--list` ile listeleme.
- **`--execute` flag'i KALDIRILDI** (issue #124 kabul kriteri: "flag execute etmeli veya kaldırılmalı"): task modelini netleştirmeden önce no-op flag taşımak yerine, `riks task <goal>` yalnızca queue'lar (`queued` status, test ile doğrulandı). Bilinmeyen `--execute` artık fail-closed: `error: unexpected argument(s): --execute` + exit 2, queue'ya yazıLMaz (test ile doğrulandı).

### 5. `riks reflect --session <id>`
- Gerçek `ReflectionAnalyzer` (fallback analiz yolu, LLM çağrısı yok) → lesson'lar kalıcı store'a yazılır (`lessons.json`).
- Konuşma kaynağı: `--transcript <json>` varsa o; yoksa kalıcı context window içeriği. İkisi de boşsa gerçek hata + exit 1.

## Teknik
- `ContextWindowManager.prune_before(older_than_days, type_filter)` eklendi (kalıcılı store ile entegre, persistence'a yazılır).
- `clear()` artık pruning stats sıfırlar + boş state'i persist eder. **Davranış değişikliği:** `ContextWindowManager.clear()`, pruning istatistik sayaçlarını (`pruning_count`, `last_prune_timestamp`) sıfırlar; clear sonrası `riks context stats` bu sayaçların 0 olduğunu gösterir.
- `main(argv)` imzası test için parametrelebilir yapıldı — **geriye uyumlu** (`main(argv: list[str] | None = None)`, varsayılan `None` → `sys.argv`), mevcut `main()` çağrıları etkilenmez.
- "not implemented yet" placeholder mesajı kaldırıldı (tüm komutlar implemente; `memory stats` hâlâ dürüstçe "not implemented yet" bildirir — turn 3).

## Testler (≥1 integration test/komut, tmp dir + gerçek store)
- **20 yeni test** (`tests/test_cli_context_task_reflect.py`): context stats (empty/data/tenant), prune (days/type/hata yolları), clear (onay y/n/EOF/—yes), task (add/list/--execute kaldırıldı→exit 2/hata yolları/tenant izolasyon), reflect (transcript/context window/hata yolları).
- 3 eski "not implemented" testi güncellendi (yeni gerçek davranışı doğruluyor).
- Lokal: **mypy clean, ruff clean, 508 passed / 5 skipped / 8 xfailed** (488→508).

## Kapsam dışı (sonraki tur/PR)
- `task --execute` gerçek execute implementasyonu — flag kaldırıldı; geri gelmeden önce önce task modeli netleşmeli (ayrı PBI olarak önerildi).
- API.md otomatik üretim (#123 turn 2).

## Risk
- `ContextWindowManager.clear()` davranışı değişti: artık pruning stats'ı sıfırlar ve boş state'i persist eder. **Mevcut kullanım uyumlu:** clear() bugün zaten sonrasız çağrılıyor ve pruning sayaçlarının clear sonrası sıfırlanması beklenen semantik; API tarafında `clear()` çağrısı yok (sadece context manager kullanımı).
- `main()` imzası `main(argv: list[str] | None = None)` — geriye uyumlu (varsayılan None → sys.argv).


