### PR TITLE
feat(api): #123 turn 2 — spec/docs URL'leri açıkça pin + health/models Field examples

### DIFF
--- a/src/riks_context_engine/api/server.py
+++ b/src/riks_context_engine/api/server.py
@@ -608,10 +608,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     _ws_streamer = None
 
 
+# #123 turn 2: spec/docs paths are pinned explicitly (FastAPI defaults are
+# implicit; making them explicit lets tests assert the contract directly).
+OPENAPI_URL = "/openapi.json"
+DOCS_URL = "/docs"
+REDOC_URL = "/redoc"
+
 app = FastAPI(
     title="Rik's Context Engine API",
     description="HTTP API for AI context and memory management",
     version="0.4.0",
+    openapi_url=OPENAPI_URL,
+    docs_url=DOCS_URL,
+    redoc_url=REDOC_URL,
     lifespan=lifespan,
 )
 
@@ -635,11 +644,12 @@ app.add_api_websocket_route("/ws/v1/context/stream", websocket_context_stream)
 
 
 class HealthResponse(BaseModel):
-    status: str
+    # #123: examples ride in the OpenAPI spec via Field (turn 2).
+    status: str = Field("ok", description="Liveness state", examples=["ok"])
 
 
 class ModelsResponse(BaseModel):
-    models: list[str]
+    models: list[str] = Field(description="Available chat models", examples=[["gemma4-31b-it"]])
 
 
 class ContextMessageResponse(BaseModel):
@@ -667,13 +677,13 @@ class ContextSummaryResponse(BaseModel):
     last_prune_timestamp: str | None
 
 
-@app.get("/health", response_model=HealthResponse, tags=["health"])
+@app.get("/health", response_model=HealthResponse, response_model_by_alias=True, tags=["health"])
 def health() -> dict[str, str]:
     """Liveness probe."""
     return {"status": "ok"}
 
 
-@app.get("/models", response_model=ModelsResponse, tags=["models"])
+@app.get("/models", response_model=ModelsResponse, response_model_by_alias=True, tags=["models"])
 def list_models() -> dict[str, list[str]]:
     """List available chat models."""
     return {"models": _MODELS}
@@ -878,8 +888,9 @@ def import_memory_api(req: MemoryImportRequest) -> MemoryImportResponse:
 
 
 # ─── OpenAPI examples (#123) ─────────────────────────────────────────────────
-# FastAPI serves /openapi.json and /docs automatically; the spec paths are
-# NOT in _API_KEY_PROTECTED_PATHS, so auth/tenant middleware never blocks
+# FastAPI serves /openapi.json + /docs + /redoc from the URLs pinned at app
+# construction (OPENAPI_URL/DOCS_URL/REDOC_URL, #123 turn 2); the spec paths
+# are NOT in _API_KEY_PROTECTED_PATHS, so auth/tenant middleware never blocks
 # them. Examples enrich the auto-generated spec with real payloads.
 
 _OPENAPI_INFO_EXAMPLES: dict[str, dict[str, Any]] = {

--- a/tests/test_api/test_openapi.py
+++ b/tests/test_api/test_openapi.py
@@ -56,6 +56,45 @@ class TestSpecExposure:
         assert spec["info"]["title"] == "Rik's Context Engine API"
         assert spec["info"]["version"]
 
+    def test_spec_urls_pinned_in_app(self, client: TestClient):
+        # #123 turn 2: openapi_url/docs_url/redoc_url are pinned explicitly on
+        # the app (asserted via the served artifacts + module-level constants).
+        from riks_context_engine.api.server import (
+            DOCS_URL,
+            OPENAPI_URL,
+            REDOC_URL,
+        )
+        from riks_context_engine.api.server import (
+            app as fastapi_app,
+        )
+
+        assert fastapi_app.openapi_url == OPENAPI_URL == "/openapi.json"
+        assert fastapi_app.docs_url == DOCS_URL == "/docs"
+        assert fastapi_app.redoc_url == REDOC_URL == "/redoc"
+        # The pinned URLs actually serve.
+        assert client.get(OPENAPI_URL).status_code == 200
+        assert client.get(DOCS_URL).status_code == 200
+        assert client.get(REDOC_URL).status_code == 200
+
+    def test_health_and_models_have_field_examples(self, spec):
+        """#123: every v1 endpoint needs a sample payload; health/models use
+        Field(examples=[...]) on the response model → `examples` shows up on
+        the 200 response content."""
+        for path, prop in (("/health", "status"), ("/models", "models")):
+            resp = spec["paths"][path]["get"]["responses"]["200"]
+            schema = resp["content"]["application/json"]["schema"]
+            # Resolve $ref (FastAPI inline schema refs) — the component has the
+            # field with the examples.
+            if "$ref" in schema:
+                ref = schema["$ref"].rsplit("/", 1)[-1]
+                comp = spec["components"]["schemas"][ref]
+            else:
+                comp = schema
+            assert prop in comp["properties"], f"{path}: {prop} missing from schema"
+            assert "examples" in comp["properties"][prop], (
+                f"{path}: {prop} has no examples in OpenAPI spec"
+            )
+
 
 class TestEndpointCoverage:
     def test_all_v1_endpoints_in_spec(self, spec):


### PR DESCRIPTION
## Summary

#123 turn 2 dispatch (PM): OpenAPI spec/docs URL'leri **açıkça** pin'lenir + `health`/`models` response modelleri `Field(examples=[...])` ile örnek payload taşır. Turn 1 (#135) zaten spec'i tüm v1 endpoint'lerine açmıştı; bu PR kalan 2 kritere dokunuyor.

## Ne yapıldı

### 1. Spec/docs URL'leri açıkça pin'lenmiş (kriter 1-2)
- `OPENAPI_URL = "/openapi.json"`, `DOCS_URL = "/docs"`, `REDOC_URL = "/redoc"` module constants.
- `FastAPI(..., openapi_url=OPENAPI_URL, docs_url=DOCS_URL, redoc_url=REDOC_URL, ...)` — FastAPI default'leri artık implicit değil; testler `app.openapi_url/docs_url/redoc_url` üzerinden kontratı doğruluyor.
- Spec paths `_API_KEY_PROTECTED_PATHS` içinde değil (turn 1'de doğrulandı) → auth/tenant middleware bloklamıyor.

### 2. `health` + `models` `Field(examples=[...])` (kriter 3)
- `HealthResponse.status: str = Field("ok", description="Liveness state", examples=["ok"])`.
- `ModelsResponse.models: list[str] = Field(description="Available chat models", examples=[["gemma4-31b-it"]])`.
- `response_model_by_alias=True` (alias-safe serialization; default alias'te davranış değişmez).
- Diğer v1 endpoint'leri (context add/list/summary, memory export/import, chat) turn 1'deki `_apply_openapi_examples` ile zenginleştirilmiş durumda — bu PR'da dokunulmadı.

### 3. Integration test'ler (kriter 4)
- `tests/test_api/test_openapi.py` +2 test:
  - `test_spec_urls_pinned_in_app`: `app.openapi_url/docs_url/redoc_url` == module constants; pin'li URL'ler servis ediyor (GET /openapi.json, /docs, /redoc → 200).
  - `test_health_and_models_have_field_examples`: spec components'ta `HealthResponse.status` ve `ModelsResponse.models` alanlarının `examples` anahtarı dolu.
- Mevcut 13 test (`test_openapi.py`) dokunulmadı — endpoint coverage, response schemas, request schemas, examples, tags, middleware pass-through hepsi hâlâ geçiyor.

## Teknik
- `src/riks_context_engine/api/server.py`: FastAPI app factory + `HealthResponse`/`ModelsResponse` + 2 route decorator.
- `tests/test_api/test_openapi.py`: 2 yeni test (module-level import `from riks_context_engine.api.server import app` zaten mevcut).
- Breaking change yok (yeni endpoint/param yok).

## Testler
- **510 passed / 5 skipped / 8 xfailed** (510 = 488 base + 20 #124 merge + 2 bu PR; #136 merge sonrası master'da 508 idi, +2 bu PR'ın).
- ruff clean, mypy clean.

## Kapsam dışı (turn 3)
- `docs/API.md` otomatik üretim (issue: "bir sonraki PR'da API.md'yi spec'ten otomatik üretime çevir").

## Risk
- Yok. Yeni endpoint/param yok; mevcut davranış korundu. `response_model_by_alias=True` health/models'de default alias'te no-op.
