### PR TITLE
fix(ci): #140 — PR Triage Check PR template quote-safe (env + printf, body only in env block)

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -70,11 +70,26 @@ jobs:
 
       - name: Check PR template
         run: |
-          # Verify PR description length
-          body_length=$(echo "${{ github.event.pull_request.body }}" | wc -c)
+          # Verify PR description length.
+          # #140: the body is passed via env + printf '%s' (literal
+          # transfer) so quotes, newlines, $ and backticks in the PR body
+          # cannot break the shell. The previous inline
+          # echo-of-the-body pattern broke on any PR body containing a
+          # single quote (e.g. Rik's, don't). A heredoc was also tried but
+          # is NOT safe: the delimiter line must start at column 0, while
+          # GitHub Actions indents the run: | block (YAML block scalar) —
+          # so the delimiter is never recognized. env + printf is the
+          # robust fix. Do NOT add the body expression back into the run
+          # block's comments: GitHub Actions substitutes EVERY
+          # github.event expression in the whole step (run + env +
+          # comments), so an in-comment reference would inline the body
+          # into a comment line and break the shell.
+          body_length=$(printf '%s' "$PR_BODY" | wc -c)
           if [ "$body_length" -lt 50 ]; then
             echo "WARNING: PR description is very short. Please add details."
           fi
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
 
   # ===== Automate Project Board ===== #
   sync-project:

--- a/tests/test_workflow_pr_triage.py
+++ b/tests/test_workflow_pr_triage.py
@@ -1,0 +1,186 @@
+"""Tests for the PR Triage workflow fix (#140).
+
+Validates that the ``Check PR template`` step in
+``.github/workflows/issues.yml`` survives a PR body containing single
+quotes (``Rik's``, ``don't``), double quotes, newlines, ``$`` and backticks.
+
+The previous implementation inlined the PR body expression directly into
+the ``run: |`` block. GitHub Actions inlines the expression on a single
+line; any single quote in the PR body broke the shell quoting and produced
+``unexpected EOF while looking for matching `'``. The fix passes the body
+via ``env: PR_BODY`` and uses ``printf '%s'`` (literal transfer, no shell
+interpretation).
+
+CRITICAL (discovered while testing the first attempt, PR #142): GitHub
+Actions substitutes EVERY ``github.event.*`` expression in the whole step
+— ``run``, ``env`` AND **comments** alike. So the body expression must
+appear ONLY in the ``env:`` block, never in a ``run: |`` comment. These
+tests enforce that invariant.
+
+The tests simulate the workflow step locally (GitHub Actions is not
+available in the test environment) by extracting the step, setting the env
+var with a hostile PR body, and executing the ``run: |`` block in ``bash
+-e``. They assert the step runs without a shell error and the WARNING echo
+fires when the body is short.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "issues.yml"
+
+
+def _load_workflow() -> dict:
+    with WORKFLOW_PATH.open() as fh:
+        data = yaml.safe_load(fh)
+    assert isinstance(data, dict)
+    return data
+
+
+def _find_step(job: dict, step_name: str) -> dict:
+    """Return the step dict for a named step in a job."""
+    for step in job.get("steps", []):
+        assert isinstance(step, dict)
+        if step.get("name") == step_name:
+            assert step.get("run"), f"step {step_name!r} has no run block"
+            return step
+    pytest.fail(f"step {step_name!r} not found in job")
+
+
+def _simulate_step(step: dict, pr_body: str) -> subprocess.CompletedProcess:
+    """Execute the step's run block with the PR body set in the env.
+
+    Mirrors what GitHub Actions does: the ``env:`` block's
+    ``PR_BODY`` variable is set to the (literal) PR body, and the
+    ``run: |`` block is executed with that env. The run block must NOT
+    contain the body expression (it is only in ``env:``); the simulation
+    only sets the env var and runs the block.
+    """
+    run_block = step.get("run", "")
+    env = dict(step.get("env") or {})
+    env["PR_BODY"] = pr_body
+    env_str = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
+    return subprocess.run(
+        ["bash", "-e", "-c", f"env {env_str} bash -e -c " + shlex.quote(run_block)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+HOSTILE_BODIES = [
+    # Single quotes (the #140 regression).
+    "Rik's Context Engine PR — don't merge this",
+    "It's a test: 'single' and \"double\" quotes",
+    # Newlines + backticks + $.
+    "line one\nline two\n`backtick` $HOME ${PATH}",
+    # Very short body (triggers the WARNING branch).
+    "x" * 10,
+    # Realistic PR body with apostrophes.
+    "## Summary\nRik's API works now. Don't break it.\n\n" + "details " * 10,
+]
+
+
+class TestCheckPRTemplate:
+    def test_body_expression_only_in_env(self):
+        """#140 regression guard: the body expression must appear ONLY in
+        the env block, never in the run block (not even in a comment).
+
+        GitHub Actions substitutes EVERY github.event expression in the
+        whole step (run + env + comments). An in-comment reference would
+        inline the body into a comment line → `bad substitution` /
+        `unexpected EOF` (PR #142 first attempt, run 32213835576).
+        """
+        wf = _load_workflow()
+        job = wf["jobs"]["triage-pr"]
+        step = _find_step(job, "Check PR template")
+        run = step.get("run", "")
+        env = step.get("env") or {}
+        assert "PR_BODY" in env, "fix must pass the body via env: PR_BODY"
+        assert "github.event.pull_request.body" not in run, (
+            "the body expression must NOT appear in the run block "
+            "(not even in a comment) — GitHub Actions substitutes it "
+            "everywhere in the step and inlines the body into the script"
+        )
+
+    def test_run_uses_printf(self):
+        wf = _load_workflow()
+        job = wf["jobs"]["triage-pr"]
+        step = _find_step(job, "Check PR template")
+        assert "printf '%s'" in step.get("run", ""), (
+            "fix must use printf '%s' (safe literal transfer)"
+        )
+
+    @pytest.mark.parametrize("body", HOSTILE_BODIES)
+    def test_step_succeeds_with_hostile_body(self, body: str):
+        """The step must NOT crash on any of these bodies."""
+        wf = _load_workflow()
+        job = wf["jobs"]["triage-pr"]
+        step = _find_step(job, "Check PR template")
+        result = _simulate_step(step, body)
+        assert result.returncode == 0, (
+            f"shell failed on body {body!r}:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        # No shell syntax error (the #140 regression).
+        assert "unexpected EOF" not in result.stderr, (
+            f"regression: shell syntax error on body {body!r}:\n{result.stderr}"
+        )
+        assert "bad substitution" not in result.stderr, (
+            f"regression: bad substitution on body {body!r}:\n{result.stderr}"
+        )
+
+    def test_warning_fires_on_short_body(self):
+        """A short body must trigger the WARNING echo (existing behavior)."""
+        wf = _load_workflow()
+        job = wf["jobs"]["triage-pr"]
+        step = _find_step(job, "Check PR template")
+        result = _simulate_step(step, "short")
+        assert result.returncode == 0
+        assert "WARNING: PR description is very short" in result.stdout
+
+    def test_no_warning_on_long_body(self):
+        """A long body must NOT trigger the WARNING echo."""
+        wf = _load_workflow()
+        job = wf["jobs"]["triage-pr"]
+        step = _find_step(job, "Check PR template")
+        result = _simulate_step(step, "long " * 50)
+        assert result.returncode == 0
+        assert "WARNING" not in result.stdout
+
+
+class TestOtherRunBlocks:
+    """Kritik 4: other quote-sensitive run: | blocks in the same workflow."""
+
+    def test_no_other_step_inlines_pr_body(self):
+        # Only the Check PR template step may reference the PR body, and it
+        # must do so via the env block (not the run block).
+        wf = _load_workflow()
+        for job_name, job in wf["jobs"].items():
+            for step in job.get("steps", []):
+                if not isinstance(step, dict) or "run" not in step:
+                    continue
+                run = step["run"]
+                if "github.event.pull_request.body" in run:
+                    pytest.fail(
+                        f"job {job_name!r} step {step.get('name')!r} inlines "
+                        f"the PR body into the run block — quote-unsafe"
+                    )
+
+    def test_parse_pr_step_is_quote_safe(self):
+        # The "Parse PR" step echoes the PR title/number/base.ref inside
+        # double quotes; a single quote in the title is harmless (bash only
+        # treats ' specially outside double quotes). We do NOT execute this
+        # step's run block (it contains unrelated ${{ ... }} expressions
+        # that would fail as shell syntax); we assert structural safety.
+        wf = _load_workflow()
+        job = wf["jobs"]["triage-pr"]
+        step = _find_step(job, "Parse PR")
+        run = step.get("run", "")
+        assert 'echo "PR: ${{ github.event.pull_request.title }}"' in run
+        assert "github.event.pull_request.body" not in run


### PR DESCRIPTION
## Summary

#140: `.github/workflows/issues.yml`'deki `triage-pr` job'ının `Check PR template` step'i **quote-safe** yapıldı (env + `printf '%s'`). Body expression **yalnızca `env:` block'unda** — run block'unda (comment dahi değil) HİÇ yok.

## İki regression (test edilirken tespit edildi, test'te dokümante)

1. **PR #138 run `32206963635`:** önceki inline `echo "${{ github.event.pull_request.body }}"` → PR body'sindeki tek tırnak (`Rik's`, `don't`) shell quoting'ini bozdu → `unexpected EOF while looking for matching '`.
2. **PR #142 ilk deneme run `32213835576`:** env+printf fix'i uygulanmıştı AMA run block'undaki **comment'te** eski pattern'i dokümante etmek için body expression'a atıf vardı → GitHub Actions **step'in TAMAMINDAKİ** (run + env + **comment**) `github.event` expression'ını substitute ediyor → body comment satırına inline'landı → `bad substitution`.

**Çıkarım:** GitHub Actions, step'in her yerindeki (run, env, comment) `github.event.*` expression'ını inline'lar. Body expression **yalnızca `env:` block'unda** olmalı; run block'unda (comment dahi değil) hiç olmamalı.

## Fix

- `env: PR_BODY: ${{ github.event.pull_request.body }}` (body expression YALNIZCA burada).
- `body_length=$(printf '%s' "$PR_BODY" | wc -c)` — env var üzerinden **literal transfer** (shell yorumlamaz); `printf '%s'` tırnak/newline/`$`/backtick'ı güvenli aktarır.
- Run block'taki comment **body expression'a atıf içermiyor** (sadece davranışı açıklıyor, expression yazmıyor).
- **Heredoc NEDEN değil:** `<<'EOF_BODY'` delimiter satırı column 0'da başlamak zorunda; GitHub Actions `run: |` block'unu indent'liyor (YAML block scalar) → delimiter asla tanınmıyor. env + `printf` robust fix.
- WARNING echo davranışı korunuyor (kısa PR description'ı → "WARNING: PR description is very short").

## Test (`tests/test_workflow_pr_triage.py`, 11 test)

- **Regression guard (yeni):** body expression **yalnızca env block'unda** olmalı — run block'unda (comment dahi değil) HİÇ olmamalı. `test_body_expression_only_in_env` bu invariant'ı doğruluyor.
- Step lokal simülasyon: env var'a hostile PR body set + run block `bash -e` ile çalıştırılıyor.
- **Hostile body'ler** (tek tırnak, çift tırnak, newline, backtick, `$`, kısa/uzun) → step CRASH ETMEMELİ + `unexpected EOF` / `bad substitution` stderr'de GÖRÜLMEMELİ.
- Kısa body → WARNING echo (mevcut davranış korunuyor); uzun body → WARNING yok.
- **Kritik 4:** workflow'daki başka step'te `github.event.pull_request.body` inline'ı YOK (Issue Triage + Sync Project Board JS `github-script` kullanıyor, bash run: | block değil).

## Teknik
- Workflow script değişikliği; Python kodu değişmedi (sadece yeni test dosyası).
- Breaking change yok.
- **Doğrulama:** bu PR'ın body'si tek tırnak içeriyor (`Rik's`, `don't`) → merge öncesi PR Triage check'i **PASS** olmalı (fix'in doğrudan doğrulaması).

## Testler
- Lokal: **ruff clean, mypy clean, 537 passed / 7 skipped / 8 xfailed**.
- CI beklentisi: PR Triage PASS (body'de tek tırnak var) + teknik checkler pass. Org-403 (PR Labels) bilinen.
