### PR TITLE
feat(mcp): #108 — tenant-scoped semantic_write + cross-process safe memory stores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0",
     "pyyaml>=6.0",
+    "filelock>=3.13",
 ]
 
 [project.optional-dependencies]

--- a/src/riks_context_engine/cli/main.py
+++ b/src/riks_context_engine/cli/main.py
@@ -42,15 +42,17 @@ def _memory_store_paths() -> tuple[str, str, str]:
 
     RIKS_TENANT_ID empty/absent → default tenant (shared legacy paths).
     """
-    sem_db, epi_json, proc_json = _store_paths()
-    tenant = os.environ.get("RIKS_TENANT_ID", "").strip()
-    if not tenant:
+    from riks_context_engine.multi_tenant import tenant_store_paths
+
+    data_dir = os.environ.get("RIKS_DATA_DIR", "data")
+    tenant = os.environ.get("RIKS_TENANT_ID", "").strip() or None
+    sem_db, epi_json, proc_json = tenant_store_paths(data_dir, tenant)
+    if tenant:
         return sem_db, epi_json, proc_json
-    base = os.path.join(os.environ.get("RIKS_DATA_DIR", "data"), "tenants", tenant)
     return (
-        os.path.join(base, "semantic.db"),
-        os.path.join(base, "episodic.json"),
-        os.path.join(base, "procedural.json"),
+        os.environ.get("RIKS_SEMANTIC_DB", sem_db),
+        os.environ.get("RIKS_EPISODIC_JSON", epi_json),
+        os.environ.get("RIKS_PROCEDURAL_JSON", proc_json),
     )
 
 

--- a/src/riks_context_engine/mcp/handlers.py
+++ b/src/riks_context_engine/mcp/handlers.py
@@ -5,15 +5,30 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import BaseModel, Field, ValidationError
+
 from ..context.manager import ContextWindowManager
 from ..memory import EpisodicMemory, ProceduralMemory, SemanticMemory
-from ..multi_tenant import TenantContextRegistry, TenantValidationError, validate_tenant_id
+from ..multi_tenant import (
+    TenantContextRegistry,
+    TenantMemoryRegistry,
+    TenantValidationError,
+    validate_tenant_id,
+)
 
 logger = logging.getLogger(__name__)
 
 
 class TenantIsolationError(Exception):
     """Raised when a tool call fails tenant validation/isolation."""
+
+
+class SemanticWriteParams(BaseModel, extra="forbid"):
+    tenant_id: str
+    subject: str = Field(min_length=1, max_length=512)
+    predicate: str = Field(min_length=1, max_length=512)
+    object: str | None = Field(default=None, max_length=4096)
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
 
 
 class ToolHandler:
@@ -34,20 +49,27 @@ class ToolHandler:
         self._procedural = procedural_memory
         self._context = context_manager
         self._tenant_registry = tenant_registry or TenantContextRegistry()
+        self._memory_registry = TenantMemoryRegistry(data_dir=self.data_dir)
 
     # -- Lazy initialisers ---------------------------------------------------
 
-    def _get_episodic(self) -> EpisodicMemory:
+    def _get_episodic(self, tenant_id: str | None = None) -> EpisodicMemory:
+        if tenant_id:
+            return self._memory_registry.get_episodic(tenant_id)
         if self._episodic is None:
             self._episodic = EpisodicMemory(f"{self.data_dir}/episodic.json")
         return self._episodic
 
-    def _get_semantic(self) -> SemanticMemory:
+    def _get_semantic(self, tenant_id: str | None = None) -> SemanticMemory:
+        if tenant_id:
+            return self._memory_registry.get_semantic(tenant_id)
         if self._semantic is None:
             self._semantic = SemanticMemory(f"{self.data_dir}/semantic.db")
         return self._semantic
 
-    def _get_procedural(self) -> ProceduralMemory:
+    def _get_procedural(self, tenant_id: str | None = None) -> ProceduralMemory:
+        if tenant_id:
+            return self._memory_registry.get_procedural(tenant_id)
         if self._procedural is None:
             self._procedural = ProceduralMemory(f"{self.data_dir}/procedural.json")
         return self._procedural
@@ -111,6 +133,38 @@ class ToolHandler:
         except Exception as exc:
             logger.error("semantic_query failed: %s", exc)
             raise
+
+    def semantic_write(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Write a semantic triple to tenant-scoped memory (#108)."""
+        try:
+            validated = SemanticWriteParams(**params)
+        except ValidationError as exc:
+            first = exc.errors()[0]
+            field = ".".join(str(loc) for loc in first["loc"])
+            raise TenantIsolationError(
+                f"Validation failed on field '{field}': {first['msg']}"
+            ) from exc
+
+        try:
+            tenant_id = validate_tenant_id(validated.tenant_id)
+        except TenantValidationError as exc:
+            raise TenantIsolationError(str(exc)) from exc
+
+        semantic = self._get_semantic(tenant_id)
+        entry = semantic.add(
+            subject=validated.subject,
+            predicate=validated.predicate,
+            object=validated.object,
+            confidence=validated.confidence,
+        )
+        return {
+            "id": entry.id,
+            "subject": entry.subject,
+            "predicate": entry.predicate,
+            "object": entry.object,
+            "confidence": entry.confidence,
+            "status": "written",
+        }
 
     def procedural_get(self, params: dict[str, Any]) -> dict[str, Any]:
         """Get procedural memory entries by tag or ID."""

--- a/src/riks_context_engine/mcp/schemas.py
+++ b/src/riks_context_engine/mcp/schemas.py
@@ -145,6 +145,40 @@ TOOL_SCHEMAS = {
             "required": ["tenant_id"],
         },
     },
+    "semantic_write": {
+        "name": "semantic_write",
+        "description": "Write a semantic knowledge triple (subject-predicate-object) to tenant-scoped memory.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "tenant_id": {
+                    "type": "string",
+                    "description": "Tenant id (X-Tenant-Id); required for isolation",
+                },
+                "subject": {
+                    "type": "string",
+                    "description": "Subject of the knowledge triple",
+                },
+                "predicate": {
+                    "type": "string",
+                    "description": "Predicate/relation of the knowledge triple",
+                },
+                "object": {
+                    "type": "string",
+                    "description": "Object of the knowledge triple (optional)",
+                },
+                "confidence": {
+                    "type": "number",
+                    "description": "Confidence 0.0-1.0 (default 1.0)",
+                    "default": 1.0,
+                    "minimum": 0.0,
+                    "maximum": 1.0,
+                },
+            },
+            "required": ["tenant_id", "subject", "predicate"],
+            "additionalProperties": False,
+        },
+    },
     "health_check": {
         "name": "health_check",
         "description": "Check if the MCP server is healthy and responsive.",

--- a/src/riks_context_engine/mcp/server.py
+++ b/src/riks_context_engine/mcp/server.py
@@ -18,7 +18,7 @@ import os
 import sys
 from typing import Any
 
-from .handlers import create_handler
+from .handlers import TenantIsolationError, create_handler
 from .protocol import (
     ERR_INTERNAL_ERROR,
     ERR_INVALID_PARAMS,
@@ -107,7 +107,10 @@ class MCPServer:
         if not handler_method or not callable(handler_method):
             raise JsonRpcError(ERR_METHOD_NOT_FOUND, f"No handler for tool: {tool_name}")
 
-        result = handler_method(tool_args)
+        try:
+            result = handler_method(tool_args)
+        except TenantIsolationError as exc:
+            raise JsonRpcError(ERR_INVALID_PARAMS, str(exc)) from exc
 
         return {
             "content": [

--- a/src/riks_context_engine/memory/episodic.py
+++ b/src/riks_context_engine/memory/episodic.py
@@ -80,9 +80,7 @@ class EpisodicMemory:
             for eid, e in self._entries.items()
         }
         with self._lock:
-            fd, tmp = tempfile.mkstemp(
-                dir=str(Path(self.storage_path).parent), suffix=".tmp"
-            )
+            fd, tmp = tempfile.mkstemp(dir=str(Path(self.storage_path).parent), suffix=".tmp")
             try:
                 os.write(fd, json.dumps(data, indent=2).encode())
                 os.close(fd)

--- a/src/riks_context_engine/memory/episodic.py
+++ b/src/riks_context_engine/memory/episodic.py
@@ -1,8 +1,13 @@
 """Episodic memory - session-level, short-term observations."""
 
+import json
+import os
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+
+from filelock import FileLock
 
 
 @dataclass
@@ -28,37 +33,41 @@ class EpisodicMemory:
 
     def __init__(self, storage_path: str | None = None):
         self.storage_path = storage_path or "data/episodic.json"
+        self._is_memory = self.storage_path == ":memory:"
         self._entries: dict[str, EpisodicEntry] = {}
+        if not self._is_memory:
+            self._lock = FileLock(f"{self.storage_path}.lock", timeout=10)
         self._load()
 
     def _load(self) -> None:
         """Load entries from disk if available."""
+        if self._is_memory:
+            return
         path = Path(self.storage_path)
-        if path.exists():
-            import json
-
-            try:
-                data = json.loads(path.read_text())
-                for d in data.values():
-                    ts = d["timestamp"]
-                    if isinstance(ts, str):
-                        ts = datetime.fromisoformat(ts)
-                    self._entries[d["id"]] = EpisodicEntry(
-                        id=d["id"],
-                        timestamp=ts,
-                        content=d["content"],
-                        importance=d.get("importance", 0.5),
-                        embedding=d.get("embedding"),
-                        tags=d.get("tags"),
-                    )
-            except (json.JSONDecodeError, KeyError, ValueError):
-                pass  # Start fresh on corruption
+        with self._lock:
+            if path.exists():
+                try:
+                    data = json.loads(path.read_text())
+                    for d in data.values():
+                        ts = d["timestamp"]
+                        if isinstance(ts, str):
+                            ts = datetime.fromisoformat(ts)
+                        self._entries[d["id"]] = EpisodicEntry(
+                            id=d["id"],
+                            timestamp=ts,
+                            content=d["content"],
+                            importance=d.get("importance", 0.5),
+                            embedding=d.get("embedding"),
+                            tags=d.get("tags"),
+                        )
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    pass  # Start fresh on corruption
 
     def _save(self) -> None:
         """Persist entries to disk."""
+        if self._is_memory:
+            return
         Path(self.storage_path).parent.mkdir(parents=True, exist_ok=True)
-        import json
-
         data = {
             eid: {
                 "id": e.id,
@@ -70,7 +79,21 @@ class EpisodicMemory:
             }
             for eid, e in self._entries.items()
         }
-        Path(self.storage_path).write_text(json.dumps(data, indent=2))
+        with self._lock:
+            fd, tmp = tempfile.mkstemp(
+                dir=str(Path(self.storage_path).parent), suffix=".tmp"
+            )
+            try:
+                os.write(fd, json.dumps(data, indent=2).encode())
+                os.close(fd)
+                fd = -1
+                os.replace(tmp, self.storage_path)
+            except BaseException:
+                if fd >= 0:
+                    os.close(fd)
+                if os.path.exists(tmp):
+                    os.unlink(tmp)
+                raise
 
     def add(
         self,

--- a/src/riks_context_engine/memory/procedural.py
+++ b/src/riks_context_engine/memory/procedural.py
@@ -1,9 +1,13 @@
 """Procedural memory - skills, workflows, how-to knowledge."""
 
 import json
+import os
+import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+
+from filelock import FileLock
 
 
 @dataclass
@@ -30,38 +34,46 @@ class ProceduralMemory:
 
     def __init__(self, storage_path: str | None = None):
         self.storage_path = storage_path or "data/procedural.json"
+        self._is_memory = self.storage_path == ":memory:"
         self._procedures: dict[str, Procedure] = {}
+        if not self._is_memory:
+            self._lock = FileLock(f"{self.storage_path}.lock", timeout=10)
         self._load()
 
     def _load(self) -> None:
         """Load procedures from disk."""
+        if self._is_memory:
+            return
         path = Path(self.storage_path)
-        if path.exists():
-            try:
-                data = json.loads(path.read_text())
-                for d in data.values():
-                    created = d["created_at"]
-                    if isinstance(created, str):
-                        created = datetime.fromisoformat(created)
-                    last_used = d["last_used"]
-                    if isinstance(last_used, str):
-                        last_used = datetime.fromisoformat(last_used)
-                    self._procedures[d["id"]] = Procedure(
-                        id=d["id"],
-                        name=d["name"],
-                        description=d["description"],
-                        steps=d.get("steps", []),
-                        created_at=created,
-                        last_used=last_used,
-                        use_count=d.get("use_count", 0),
-                        success_rate=d.get("success_rate", 1.0),
-                        tags=d.get("tags", []),
-                    )
-            except (json.JSONDecodeError, KeyError, ValueError):
-                pass
+        with self._lock:
+            if path.exists():
+                try:
+                    data = json.loads(path.read_text())
+                    for d in data.values():
+                        created = d["created_at"]
+                        if isinstance(created, str):
+                            created = datetime.fromisoformat(created)
+                        last_used = d["last_used"]
+                        if isinstance(last_used, str):
+                            last_used = datetime.fromisoformat(last_used)
+                        self._procedures[d["id"]] = Procedure(
+                            id=d["id"],
+                            name=d["name"],
+                            description=d["description"],
+                            steps=d.get("steps", []),
+                            created_at=created,
+                            last_used=last_used,
+                            use_count=d.get("use_count", 0),
+                            success_rate=d.get("success_rate", 1.0),
+                            tags=d.get("tags", []),
+                        )
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    pass
 
     def _save(self) -> None:
         """Persist procedures to disk."""
+        if self._is_memory:
+            return
         Path(self.storage_path).parent.mkdir(parents=True, exist_ok=True)
         data = {
             pid: {
@@ -77,7 +89,21 @@ class ProceduralMemory:
             }
             for pid, p in self._procedures.items()
         }
-        Path(self.storage_path).write_text(json.dumps(data, indent=2))
+        with self._lock:
+            fd, tmp = tempfile.mkstemp(
+                dir=str(Path(self.storage_path).parent), suffix=".tmp"
+            )
+            try:
+                os.write(fd, json.dumps(data, indent=2).encode())
+                os.close(fd)
+                fd = -1
+                os.replace(tmp, self.storage_path)
+            except BaseException:
+                if fd >= 0:
+                    os.close(fd)
+                if os.path.exists(tmp):
+                    os.unlink(tmp)
+                raise
 
     def store(
         self,

--- a/src/riks_context_engine/memory/procedural.py
+++ b/src/riks_context_engine/memory/procedural.py
@@ -90,9 +90,7 @@ class ProceduralMemory:
             for pid, p in self._procedures.items()
         }
         with self._lock:
-            fd, tmp = tempfile.mkstemp(
-                dir=str(Path(self.storage_path).parent), suffix=".tmp"
-            )
+            fd, tmp = tempfile.mkstemp(dir=str(Path(self.storage_path).parent), suffix=".tmp")
             try:
                 os.write(fd, json.dumps(data, indent=2).encode())
                 os.close(fd)

--- a/src/riks_context_engine/memory/semantic.py
+++ b/src/riks_context_engine/memory/semantic.py
@@ -54,6 +54,8 @@ class SemanticMemory:
     def _init_db(self) -> None:
         """Initialize the SQLite schema."""
         with self._conn() as conn:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS semantic_entries (
                     id TEXT PRIMARY KEY,

--- a/src/riks_context_engine/memory/semantic.py
+++ b/src/riks_context_engine/memory/semantic.py
@@ -191,20 +191,17 @@ class SemanticMemory:
 
     def recall(self, query: str) -> list[SemanticEntry]:
         """Semantic search across knowledge using keyword matching."""
-        q = query.lower()
+        pattern = f"%{query}%"
         with self._conn() as conn:
             conn.row_factory = sqlite3.Row
-            rows = conn.execute("SELECT * FROM semantic_entries").fetchall()
-        matches = []
-        for r in rows:
-            entry = self._row_to_entry(r)
-            if (
-                q in entry.subject.lower()
-                or q in entry.predicate.lower()
-                or (entry.object and q in entry.object.lower())
-            ):
-                matches.append(entry)
-        return matches
+            rows = conn.execute(
+                """SELECT * FROM semantic_entries
+                   WHERE subject LIKE ? COLLATE NOCASE
+                      OR predicate LIKE ? COLLATE NOCASE
+                      OR object LIKE ? COLLATE NOCASE""",
+                (pattern, pattern, pattern),
+            ).fetchall()
+        return [self._row_to_entry(r) for r in rows]
 
     def to_memory_entry(self) -> MemoryEntry:
         """Convert this SemanticEntry to a generic MemoryEntry.

--- a/src/riks_context_engine/multi_tenant.py
+++ b/src/riks_context_engine/multi_tenant.py
@@ -20,10 +20,14 @@ isolation + header validation.
 
 from __future__ import annotations
 
+import os
 import re
 import threading
 
 from riks_context_engine.context.manager import ContextWindowManager
+from riks_context_engine.memory.episodic import EpisodicMemory
+from riks_context_engine.memory.procedural import ProceduralMemory
+from riks_context_engine.memory.semantic import SemanticMemory
 
 #: Header carrying the tenant identifier on HTTP requests.
 TENANT_HEADER = "X-Tenant-Id"
@@ -73,6 +77,26 @@ def assert_same_tenant(requested: str | None, record_tenant: str, field: str = "
         raise TenantValidationError(f"{field} does not belong to this tenant")
 
 
+def tenant_store_paths(data_dir: str, tenant_id: str | None) -> tuple[str, str, str]:
+    """Return (semantic_db, episodic_json, procedural_json) for a tenant.
+
+    When ``tenant_id`` is None or empty, returns default (legacy) paths.
+    """
+    tenant = (tenant_id or "").strip()
+    if not tenant:
+        return (
+            os.path.join(data_dir, "semantic.db"),
+            os.path.join(data_dir, "episodic.json"),
+            os.path.join(data_dir, "procedural.json"),
+        )
+    base = os.path.join(data_dir, "tenants", tenant)
+    return (
+        os.path.join(base, "semantic.db"),
+        os.path.join(base, "episodic.json"),
+        os.path.join(base, "procedural.json"),
+    )
+
+
 class TenantContextRegistry:
     """Per-tenant :class:`ContextWindowManager` instances.
 
@@ -103,3 +127,45 @@ class TenantContextRegistry:
     def has(self, tenant_id: str) -> bool:
         with self._lock:
             return tenant_id in self._managers
+
+
+class TenantMemoryRegistry:
+    """Per-tenant memory store instances (semantic, episodic, procedural).
+
+    Same structural isolation as TenantContextRegistry: each tenant gets
+    its own store instances, backed by tenant-scoped file paths.
+    """
+
+    def __init__(self, data_dir: str = "data") -> None:
+        self._data_dir = data_dir
+        self._semantic: dict[str, SemanticMemory] = {}
+        self._episodic: dict[str, EpisodicMemory] = {}
+        self._procedural: dict[str, ProceduralMemory] = {}
+        self._lock = threading.Lock()
+
+    def get_semantic(self, tenant_id: str) -> SemanticMemory:
+        with self._lock:
+            mem = self._semantic.get(tenant_id)
+            if mem is None:
+                sem_db, _, _ = tenant_store_paths(self._data_dir, tenant_id)
+                mem = SemanticMemory(db_path=sem_db)
+                self._semantic[tenant_id] = mem
+            return mem
+
+    def get_episodic(self, tenant_id: str) -> EpisodicMemory:
+        with self._lock:
+            mem = self._episodic.get(tenant_id)
+            if mem is None:
+                _, epi_json, _ = tenant_store_paths(self._data_dir, tenant_id)
+                mem = EpisodicMemory(storage_path=epi_json)
+                self._episodic[tenant_id] = mem
+            return mem
+
+    def get_procedural(self, tenant_id: str) -> ProceduralMemory:
+        with self._lock:
+            mem = self._procedural.get(tenant_id)
+            if mem is None:
+                _, _, proc_json = tenant_store_paths(self._data_dir, tenant_id)
+                mem = ProceduralMemory(storage_path=proc_json)
+                self._procedural[tenant_id] = mem
+            return mem

--- a/tests/test_mcp_semantic_write.py
+++ b/tests/test_mcp_semantic_write.py
@@ -1,0 +1,138 @@
+"""Tests for the semantic_write MCP tool (#108)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from riks_context_engine.mcp.handlers import TenantIsolationError, ToolHandler
+from riks_context_engine.mcp.schemas import TOOL_SCHEMAS
+
+
+class TestSemanticWriteSchema:
+    """Verify the semantic_write tool schema is registered correctly."""
+
+    def test_schema_exists(self):
+        assert "semantic_write" in TOOL_SCHEMAS
+
+    def test_required_fields(self):
+        schema = TOOL_SCHEMAS["semantic_write"]["inputSchema"]
+        assert set(schema["required"]) == {"tenant_id", "subject", "predicate"}
+
+    def test_additional_properties_forbidden(self):
+        schema = TOOL_SCHEMAS["semantic_write"]["inputSchema"]
+        assert schema.get("additionalProperties") is False
+
+
+class TestSemanticWriteSuccess:
+    """Write + query round-trip within the same tenant."""
+
+    def test_write_and_query_same_tenant(self, tmp_path):
+        handler = ToolHandler(data_dir=str(tmp_path))
+        result = handler.semantic_write(
+            {
+                "tenant_id": "agentA",
+                "subject": "auth_service",
+                "predicate": "uses",
+                "object": "JWT RS256",
+                "confidence": 0.95,
+            }
+        )
+        assert result["status"] == "written"
+        assert result["subject"] == "auth_service"
+        assert result["predicate"] == "uses"
+        assert result["object"] == "JWT RS256"
+        assert result["confidence"] == 0.95
+        assert "id" in result
+
+        semantic = handler._get_semantic("agentA")
+        entries = semantic.query(subject="auth_service")
+        assert len(entries) == 1
+        assert entries[0].predicate == "uses"
+
+
+class TestSemanticWriteIsolation:
+    """Cross-tenant isolation: agentA's data is invisible to agentB."""
+
+    def test_cross_tenant_invisible(self, tmp_path):
+        handler = ToolHandler(data_dir=str(tmp_path))
+        handler.semantic_write(
+            {
+                "tenant_id": "agentA",
+                "subject": "secret_key",
+                "predicate": "is",
+                "object": "abc123",
+            }
+        )
+
+        path_b = os.path.join(str(tmp_path), "tenants", "agentB")
+        assert not os.path.exists(path_b), "agentB dir should not exist before query"
+
+        semantic_b = handler._get_semantic("agentB")
+        entries = semantic_b.query(subject="secret_key")
+        assert len(entries) == 0
+
+
+class TestSemanticWriteTenantValidation:
+    """Tenant id validation edge cases."""
+
+    def test_missing_tenant_id(self, tmp_path):
+        handler = ToolHandler(data_dir=str(tmp_path))
+        with pytest.raises(TenantIsolationError):
+            handler.semantic_write(
+                {"subject": "x", "predicate": "y"}
+            )
+
+    def test_empty_tenant_id(self, tmp_path):
+        handler = ToolHandler(data_dir=str(tmp_path))
+        with pytest.raises(TenantIsolationError):
+            handler.semantic_write(
+                {"tenant_id": "", "subject": "x", "predicate": "y"}
+            )
+
+    def test_path_traversal_tenant_id(self, tmp_path):
+        handler = ToolHandler(data_dir=str(tmp_path))
+        with pytest.raises(TenantIsolationError):
+            handler.semantic_write(
+                {"tenant_id": "../etc", "subject": "x", "predicate": "y"}
+            )
+
+
+class TestSemanticWriteValidation:
+    """Pydantic validation with extra='forbid'."""
+
+    def test_confidence_out_of_range(self, tmp_path):
+        handler = ToolHandler(data_dir=str(tmp_path))
+        with pytest.raises(TenantIsolationError, match="confidence"):
+            handler.semantic_write(
+                {
+                    "tenant_id": "agentA",
+                    "subject": "x",
+                    "predicate": "y",
+                    "confidence": 1.5,
+                }
+            )
+
+    def test_empty_subject(self, tmp_path):
+        handler = ToolHandler(data_dir=str(tmp_path))
+        with pytest.raises(TenantIsolationError, match="subject"):
+            handler.semantic_write(
+                {
+                    "tenant_id": "agentA",
+                    "subject": "",
+                    "predicate": "y",
+                }
+            )
+
+    def test_extra_field_rejected(self, tmp_path):
+        handler = ToolHandler(data_dir=str(tmp_path))
+        with pytest.raises(TenantIsolationError):
+            handler.semantic_write(
+                {
+                    "tenant_id": "agentA",
+                    "subject": "x",
+                    "predicate": "y",
+                    "evil_field": "drop table;",
+                }
+            )

--- a/tests/test_mcp_semantic_write.py
+++ b/tests/test_mcp_semantic_write.py
@@ -80,23 +80,17 @@ class TestSemanticWriteTenantValidation:
     def test_missing_tenant_id(self, tmp_path):
         handler = ToolHandler(data_dir=str(tmp_path))
         with pytest.raises(TenantIsolationError):
-            handler.semantic_write(
-                {"subject": "x", "predicate": "y"}
-            )
+            handler.semantic_write({"subject": "x", "predicate": "y"})
 
     def test_empty_tenant_id(self, tmp_path):
         handler = ToolHandler(data_dir=str(tmp_path))
         with pytest.raises(TenantIsolationError):
-            handler.semantic_write(
-                {"tenant_id": "", "subject": "x", "predicate": "y"}
-            )
+            handler.semantic_write({"tenant_id": "", "subject": "x", "predicate": "y"})
 
     def test_path_traversal_tenant_id(self, tmp_path):
         handler = ToolHandler(data_dir=str(tmp_path))
         with pytest.raises(TenantIsolationError):
-            handler.semantic_write(
-                {"tenant_id": "../etc", "subject": "x", "predicate": "y"}
-            )
+            handler.semantic_write({"tenant_id": "../etc", "subject": "x", "predicate": "y"})
 
 
 class TestSemanticWriteValidation:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,11 +1,13 @@
 """Tests for memory module."""
 
+import multiprocessing
 import os
 import tempfile
 
 from riks_context_engine.memory.episodic import EpisodicMemory
 from riks_context_engine.memory.procedural import ProceduralMemory
 from riks_context_engine.memory.semantic import SemanticMemory
+from riks_context_engine.multi_tenant import tenant_store_paths
 
 
 def _temp_json_path():
@@ -324,3 +326,90 @@ class TestProceduralMemoryExtended:
         proc = list(mem2.procedures.values())[0]
         assert proc.name == "Persisted Proc"
         assert proc.steps == ["step_a", "step_b"]
+
+
+# ---------------------------------------------------------------------------
+# Cross-process concurrency (#108)
+# ---------------------------------------------------------------------------
+
+
+def _semantic_writer(db_path: str, prefix: str, count: int) -> None:
+    """Worker: write `count` entries to the semantic DB."""
+    mem = SemanticMemory(db_path=db_path)
+    for i in range(count):
+        mem.add(subject=f"{prefix}_{i}", predicate="test", object="value")
+
+
+class TestCrossProcessConcurrency:
+    """4 processes x 25 writes → 100 entries, no data loss."""
+
+    def test_concurrent_semantic_writes(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        try:
+            procs = []
+            for i in range(4):
+                p = multiprocessing.Process(
+                    target=_semantic_writer,
+                    args=(db_path, f"proc{i}", 25),
+                )
+                procs.append(p)
+                p.start()
+            for p in procs:
+                p.join(timeout=30)
+            mem = SemanticMemory(db_path=db_path)
+            entries = mem.query()
+            assert len(entries) == 100, f"Expected 100 entries, got {len(entries)}"
+        finally:
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# tenant_store_paths regression (#108)
+# ---------------------------------------------------------------------------
+
+
+class TestTenantStorePaths:
+    """Verify tenant_store_paths helper produces correct paths."""
+
+    def test_legacy_paths_no_tenant(self):
+        sem, epi, proc = tenant_store_paths("data", None)
+        assert sem == os.path.join("data", "semantic.db")
+        assert epi == os.path.join("data", "episodic.json")
+        assert proc == os.path.join("data", "procedural.json")
+
+    def test_legacy_paths_empty_tenant(self):
+        sem, epi, proc = tenant_store_paths("data", "")
+        assert sem == os.path.join("data", "semantic.db")
+
+    def test_tenant_scoped_paths(self):
+        sem, epi, proc = tenant_store_paths("data", "agentX")
+        assert sem == os.path.join("data", "tenants", "agentX", "semantic.db")
+        assert epi == os.path.join("data", "tenants", "agentX", "episodic.json")
+        assert proc == os.path.join("data", "tenants", "agentX", "procedural.json")
+
+    def test_cli_regression_env_override_without_tenant(self, monkeypatch):
+        """Env var overrides apply only when no tenant is set."""
+        monkeypatch.setenv("RIKS_SEMANTIC_DB", "/custom/sem.db")
+        monkeypatch.setenv("RIKS_EPISODIC_JSON", "/custom/epi.json")
+        monkeypatch.setenv("RIKS_PROCEDURAL_JSON", "/custom/proc.json")
+        monkeypatch.delenv("RIKS_TENANT_ID", raising=False)
+        from riks_context_engine.cli.main import _memory_store_paths
+
+        sem, epi, proc = _memory_store_paths()
+        assert sem == "/custom/sem.db"
+        assert epi == "/custom/epi.json"
+        assert proc == "/custom/proc.json"
+
+    def test_cli_regression_tenant_ignores_env_override(self, monkeypatch):
+        """When tenant is set, env var overrides are ignored."""
+        monkeypatch.setenv("RIKS_SEMANTIC_DB", "/custom/sem.db")
+        monkeypatch.setenv("RIKS_TENANT_ID", "myTenant")
+        from riks_context_engine.cli.main import _memory_store_paths
+
+        sem, _, _ = _memory_store_paths()
+        assert "/custom/" not in sem
+        assert "myTenant" in sem

--- a/tests/test_thread_safe_sqlite.py
+++ b/tests/test_thread_safe_sqlite.py
@@ -178,10 +178,6 @@ class TestThreadSafeSQLite:
 
     # ── AC-51-02: WAL mode enabled ───────────────────────────────────────
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="feature gap: #51 WAL mode + write lock never merged to master (commits edd1617/3009bfd on unmerged branches); auto-passes when #51 lands",
-    )
     def test_wal_mode_is_enabled(self):
         """Verify WAL journal mode is enabled on the database."""
         with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
@@ -200,10 +196,6 @@ class TestThreadSafeSQLite:
 
         assert journal_mode.upper() == "WAL", f"Expected WAL mode, got: {journal_mode}"
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="feature gap: #51 WAL mode + write lock never merged to master (commits edd1617/3009bfd on unmerged branches); auto-passes when #51 lands",
-    )
     def test_wal_mode_persists_after_write(self):
         """WAL mode should remain enabled even after many writes."""
         with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:


### PR DESCRIPTION
## Değişiklikler

Closes #108

- **`tenant_store_paths()` helper** — `multi_tenant.py`'ye taşındı, CLI ve MCP paylaşıyor
- **`TenantMemoryRegistry`** — per-tenant lazy-init semantic/episodic/procedural store'lar, `threading.Lock` ile thread-safe
- **`semantic_write` MCP tool** — Pydantic `extra="forbid"` validation, tenant-scoped write path
- **Cross-process file lock** — `filelock` + atomik yazım (`tempfile.mkstemp` → `os.replace`) episodic & procedural store'larda
- **SQLite WAL mode** — `PRAGMA journal_mode=WAL` + `busy_timeout=5000` semantic memory'de
- **Error mapping** — `TenantIsolationError` → `ERR_INVALID_PARAMS (-32602)` MCP server'da
- **CLI delegation** — `_memory_store_paths()` artık `tenant_store_paths()` kullanıyor, env override'lar sadece tenant yokken aktif

## Test

- `test_mcp_semantic_write.py` — schema, write+query, tenant izolasyonu, path traversal, Pydantic validation (extra field, empty subject, confidence range)
- `test_memory.py` — 4-process × 25 concurrent writes = 100 entries (data loss yok), `tenant_store_paths` regression, CLI env override regression
- 592 test pass, ruff + mypy clean