### PR TITLE
feat: add task_execute MCP tool with timeout enforcement (#107)

### DIFF
--- a/src/riks_context_engine/__init__.py
+++ b/src/riks_context_engine/__init__.py
@@ -1,3 +1,3 @@
 """Rik's Context Engine - AI context and memory management framework."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/riks_context_engine/cli/task_queue.py
+++ b/src/riks_context_engine/cli/task_queue.py
@@ -16,10 +16,10 @@ from pathlib import Path
 from typing import Any
 
 
-def task_queue_path() -> str:
-    data_dir = os.environ.get("RIKS_DATA_DIR", "data")
+def task_queue_path(tenant_id: str | None = None, data_dir: str | None = None) -> str:
+    data_dir = data_dir or os.environ.get("RIKS_DATA_DIR", "data")
     base = os.path.join(data_dir, os.environ.get("RIKS_TASKS_FILE", "tasks.json"))
-    tenant = os.environ.get("RIKS_TENANT_ID", "").strip()
+    tenant = tenant_id or os.environ.get("RIKS_TENANT_ID", "").strip()
     if tenant:
         base = os.path.join(data_dir, "tenants", tenant, "tasks.json")
     return base

--- a/src/riks_context_engine/mcp/handlers.py
+++ b/src/riks_context_engine/mcp/handlers.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, ValidationError
 
+from ..cli.task_queue import TaskQueue, task_queue_path
 from ..context.manager import ContextWindowManager
 from ..memory import EpisodicMemory, ProceduralMemory, SemanticMemory
 from ..multi_tenant import (
@@ -14,6 +15,11 @@ from ..multi_tenant import (
     TenantMemoryRegistry,
     TenantValidationError,
     validate_tenant_id,
+)
+from ..tools.executor import (
+    ToolExecutionError,
+    build_default_registry,
+    execute_goal,
 )
 
 logger = logging.getLogger(__name__)
@@ -50,6 +56,7 @@ class ToolHandler:
         self._context = context_manager
         self._tenant_registry = tenant_registry or TenantContextRegistry()
         self._memory_registry = TenantMemoryRegistry(data_dir=self.data_dir)
+        self._tool_registry: Any = None
 
     # -- Lazy initialisers ---------------------------------------------------
 
@@ -303,10 +310,70 @@ class ToolHandler:
             ),
         }
 
+    def task_execute(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Execute a goal via the tool execution engine.
+
+        Timeout is mandatory and capped at 120s. On timeout, returns a normal
+        response with ``status="timeout"`` — never raises, so the stdio loop
+        stays alive.
+
+        Known limitation: on timeout the worker thread is left running as a
+        daemon (orphan). Real cancellation is tracked in a follow-up issue.
+        """
+        try:
+            tenant_id = validate_tenant_id(params.get("tenant_id"))
+        except TenantValidationError as exc:
+            raise TenantIsolationError(str(exc)) from exc
+
+        goal = params.get("goal", "")
+        if not isinstance(goal, str) or not goal.strip():
+            raise TenantIsolationError("goal must be a non-empty string")
+
+        raw_timeout = params.get("timeout")
+        if raw_timeout is None:
+            effective_timeout = 30.0
+        else:
+            effective_timeout = float(raw_timeout)
+            if effective_timeout < 1 or effective_timeout > 120:
+                raise TenantIsolationError("timeout must be between 1 and 120 seconds")
+
+        if self._tool_registry is None:
+            self._tool_registry = build_default_registry()
+
+        queue = TaskQueue(path=task_queue_path(tenant_id=tenant_id, data_dir=self.data_dir))
+        task = queue.add(goal)
+        task.owner_tenant = tenant_id
+        queue.mark(task.id, "running")
+
+        try:
+            result = execute_goal(goal, self._tool_registry, timeout=effective_timeout)
+        except ToolExecutionError as exc:
+            queue.mark(task.id, "failed", result=str(exc))
+            raise TenantIsolationError(str(exc)) from exc
+
+        if result.timed_out:
+            queue.mark(task.id, "timeout")
+            return {
+                "status": "timeout",
+                "goal": goal,
+                "timeout_seconds": effective_timeout,
+                "result": None,
+            }
+
+        queue.mark(task.id, "done", result=result.result)
+        name = goal.partition(":")[0].strip() if ":" in goal else "echo"
+        return {
+            "status": "done",
+            "tool": name,
+            "result": result.result,
+        }
+
     def health_check(self, params: dict[str, Any]) -> dict[str, Any]:
         """Return server health status."""
         del params
-        return {"status": "ok", "version": "0.2.0"}
+        from .server import SERVER_INFO
+
+        return {"status": "ok", "version": SERVER_INFO["version"]}
 
 
 def create_handler(data_dir: str | None = None) -> ToolHandler:

--- a/src/riks_context_engine/mcp/schemas.py
+++ b/src/riks_context_engine/mcp/schemas.py
@@ -179,6 +179,32 @@ TOOL_SCHEMAS = {
             "additionalProperties": False,
         },
     },
+    "task_execute": {
+        "name": "task_execute",
+        "description": "Execute a goal via the tool execution engine with mandatory timeout.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "tenant_id": {
+                    "type": "string",
+                    "description": "Tenant id (X-Tenant-Id); required for isolation",
+                },
+                "goal": {
+                    "type": "string",
+                    "description": "Goal string, e.g. 'echo: hello' (max 2048 chars)",
+                    "maxLength": 2048,
+                },
+                "timeout": {
+                    "type": "number",
+                    "description": "Timeout in seconds (default 30, max 120)",
+                    "default": 30,
+                    "minimum": 1,
+                    "maximum": 120,
+                },
+            },
+            "required": ["tenant_id", "goal"],
+        },
+    },
     "health_check": {
         "name": "health_check",
         "description": "Check if the MCP server is healthy and responsive.",

--- a/src/riks_context_engine/mcp/server.py
+++ b/src/riks_context_engine/mcp/server.py
@@ -18,6 +18,7 @@ import os
 import sys
 from typing import Any
 
+from ..tools.executor import ToolExecutionError
 from .handlers import TenantIsolationError, create_handler
 from .protocol import (
     ERR_INTERNAL_ERROR,
@@ -35,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 # Protocol version as defined in MCP spec
 PROTOCOL_VERSION = "2024-11-05"
-SERVER_INFO = {"name": "riks-context-engine", "version": "0.2.0"}
+SERVER_INFO = {"name": "riks-context-engine", "version": "0.3.0"}
 
 # Supported JSON-RPC methods
 MCP_METHODS = {
@@ -110,6 +111,8 @@ class MCPServer:
         try:
             result = handler_method(tool_args)
         except TenantIsolationError as exc:
+            raise JsonRpcError(ERR_INVALID_PARAMS, str(exc)) from exc
+        except ToolExecutionError as exc:
             raise JsonRpcError(ERR_INVALID_PARAMS, str(exc)) from exc
 
         return {

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -151,7 +151,7 @@ class TestMCPServer:
     def test_health_check(self, server: MCPServer) -> None:
         result = server.handler.health_check({})
         assert result["status"] == "ok"
-        assert result["version"] == "0.2.0"
+        assert result["version"] == "0.3.0"
 
     def test_unknown_method(self, server: MCPServer) -> None:
         request = {"jsonrpc": "2.0", "method": "nonexistent", "id": 1}

--- a/tests/test_mcp_task_execute.py
+++ b/tests/test_mcp_task_execute.py
@@ -64,20 +64,28 @@ def _call(server: MCPServer, tool_name: str, args: dict[str, Any]) -> dict[str, 
 
 class TestTaskExecuteSuccess:
     def test_echo_goal(self, server: MCPServer) -> None:
-        resp = _call(server, "task_execute", {
-            "tenant_id": "t-test",
-            "goal": "echo: merhaba",
-        })
+        resp = _call(
+            server,
+            "task_execute",
+            {
+                "tenant_id": "t-test",
+                "goal": "echo: merhaba",
+            },
+        )
         assert "result" in resp
         content = json.loads(resp["result"]["content"][0]["text"])
         assert content["status"] == "done"
         assert "merhaba" in content["result"]
 
     def test_default_tool_no_colon(self, server: MCPServer) -> None:
-        resp = _call(server, "task_execute", {
-            "tenant_id": "t-test",
-            "goal": "plain text goal",
-        })
+        resp = _call(
+            server,
+            "task_execute",
+            {
+                "tenant_id": "t-test",
+                "goal": "plain text goal",
+            },
+        )
         content = json.loads(resp["result"]["content"][0]["text"])
         assert content["status"] == "done"
         assert "plain text goal" in content["result"]
@@ -85,31 +93,47 @@ class TestTaskExecuteSuccess:
 
 class TestTaskExecuteErrors:
     def test_unknown_tool(self, server: MCPServer) -> None:
-        resp = _call(server, "task_execute", {
-            "tenant_id": "t-test",
-            "goal": "nonexistent_tool: x",
-        })
+        resp = _call(
+            server,
+            "task_execute",
+            {
+                "tenant_id": "t-test",
+                "goal": "nonexistent_tool: x",
+            },
+        )
         assert resp["error"]["code"] == ERR_INVALID_PARAMS
         assert "unknown tool" in resp["error"]["message"]
 
     def test_empty_goal(self, server: MCPServer) -> None:
-        resp = _call(server, "task_execute", {
-            "tenant_id": "t-test",
-            "goal": "",
-        })
+        resp = _call(
+            server,
+            "task_execute",
+            {
+                "tenant_id": "t-test",
+                "goal": "",
+            },
+        )
         assert resp["error"]["code"] == ERR_INVALID_PARAMS
 
     def test_missing_tenant_id(self, server: MCPServer) -> None:
-        resp = _call(server, "task_execute", {
-            "goal": "echo: hi",
-        })
+        resp = _call(
+            server,
+            "task_execute",
+            {
+                "goal": "echo: hi",
+            },
+        )
         assert resp["error"]["code"] == ERR_INVALID_PARAMS
 
     def test_invalid_tenant_id(self, server: MCPServer) -> None:
-        resp = _call(server, "task_execute", {
-            "tenant_id": "",
-            "goal": "echo: hi",
-        })
+        resp = _call(
+            server,
+            "task_execute",
+            {
+                "tenant_id": "",
+                "goal": "echo: hi",
+            },
+        )
         assert resp["error"]["code"] == ERR_INVALID_PARAMS
 
 
@@ -122,11 +146,15 @@ class TestTaskExecuteTimeout:
         server.handler._tool_registry = registry
 
         t0 = time.monotonic()
-        resp = _call(server, "task_execute", {
-            "tenant_id": "t-timeout",
-            "goal": "slow: x",
-            "timeout": 1,
-        })
+        resp = _call(
+            server,
+            "task_execute",
+            {
+                "tenant_id": "t-timeout",
+                "goal": "slow: x",
+                "timeout": 1,
+            },
+        )
         elapsed = time.monotonic() - t0
 
         content = json.loads(resp["result"]["content"][0]["text"])
@@ -141,31 +169,43 @@ class TestTaskExecuteTimeout:
         registry.register(SlowTool())
         server.handler._tool_registry = registry
 
-        _call(server, "task_execute", {
-            "tenant_id": "t-timeout2",
-            "goal": "slow: x",
-            "timeout": 1,
-        })
+        _call(
+            server,
+            "task_execute",
+            {
+                "tenant_id": "t-timeout2",
+                "goal": "slow: x",
+                "timeout": 1,
+            },
+        )
 
         ping_req = {"jsonrpc": "2.0", "id": 99, "method": "ping"}
         ping_resp = json.loads(server.dispatch(ping_req))
         assert ping_resp["result"]["pong"] is True
 
     def test_timeout_clamped_to_120(self, server: MCPServer) -> None:
-        resp = _call(server, "task_execute", {
-            "tenant_id": "t-test",
-            "goal": "echo: fast",
-            "timeout": 9999,
-        })
+        resp = _call(
+            server,
+            "task_execute",
+            {
+                "tenant_id": "t-test",
+                "goal": "echo: fast",
+                "timeout": 9999,
+            },
+        )
         assert resp["error"]["code"] == ERR_INVALID_PARAMS
 
 
 class TestTaskExecuteTenantIsolation:
     def test_tenant_scoped_queue(self, server: MCPServer, tmp_path: Path) -> None:
-        _call(server, "task_execute", {
-            "tenant_id": "agentA",
-            "goal": "echo: secret",
-        })
+        _call(
+            server,
+            "task_execute",
+            {
+                "tenant_id": "agentA",
+                "goal": "echo: secret",
+            },
+        )
 
         a_tasks = tmp_path / "data" / "tenants" / "agentA" / "tasks.json"
         assert a_tasks.exists()

--- a/tests/test_mcp_task_execute.py
+++ b/tests/test_mcp_task_execute.py
@@ -1,0 +1,200 @@
+"""Tests for task_execute MCP tool (#107).
+
+Covers:
+- Echo goal → success
+- Unknown tool → -32602
+- Empty goal → -32602
+- Timeout: slow tool, timeout=1, returns within 2s, no exception
+- Post-timeout ping → server alive
+- Timeout > 120 → schema rejects with -32602
+- Tenant isolation: agentA task not visible to agentB
+- Missing/invalid tenant_id → -32602
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from riks_context_engine.mcp.protocol import ERR_INVALID_PARAMS
+from riks_context_engine.mcp.server import SERVER_INFO, MCPServer
+from riks_context_engine.tools.base_tool import Tool
+
+
+class SlowTool(Tool):
+    """Tool that sleeps for a configurable duration (for timeout tests)."""
+
+    name = "slow"
+    description = "Sleeps for N seconds."
+    parameters = {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string"},
+        },
+        "required": ["text"],
+    }
+
+    def execute(self, params: dict[str, Any]) -> str:
+        time.sleep(10)
+        return "done"
+
+
+@pytest.fixture
+def server(tmp_path: Path) -> MCPServer:
+    s = MCPServer(data_dir=str(tmp_path / "data"))
+    s.handle_initialize({})
+    return s
+
+
+def _call(server: MCPServer, tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool_name, "arguments": args},
+    }
+    resp = server.dispatch(request)
+    assert resp is not None
+    return json.loads(resp)
+
+
+class TestTaskExecuteSuccess:
+    def test_echo_goal(self, server: MCPServer) -> None:
+        resp = _call(server, "task_execute", {
+            "tenant_id": "t-test",
+            "goal": "echo: merhaba",
+        })
+        assert "result" in resp
+        content = json.loads(resp["result"]["content"][0]["text"])
+        assert content["status"] == "done"
+        assert "merhaba" in content["result"]
+
+    def test_default_tool_no_colon(self, server: MCPServer) -> None:
+        resp = _call(server, "task_execute", {
+            "tenant_id": "t-test",
+            "goal": "plain text goal",
+        })
+        content = json.loads(resp["result"]["content"][0]["text"])
+        assert content["status"] == "done"
+        assert "plain text goal" in content["result"]
+
+
+class TestTaskExecuteErrors:
+    def test_unknown_tool(self, server: MCPServer) -> None:
+        resp = _call(server, "task_execute", {
+            "tenant_id": "t-test",
+            "goal": "nonexistent_tool: x",
+        })
+        assert resp["error"]["code"] == ERR_INVALID_PARAMS
+        assert "unknown tool" in resp["error"]["message"]
+
+    def test_empty_goal(self, server: MCPServer) -> None:
+        resp = _call(server, "task_execute", {
+            "tenant_id": "t-test",
+            "goal": "",
+        })
+        assert resp["error"]["code"] == ERR_INVALID_PARAMS
+
+    def test_missing_tenant_id(self, server: MCPServer) -> None:
+        resp = _call(server, "task_execute", {
+            "goal": "echo: hi",
+        })
+        assert resp["error"]["code"] == ERR_INVALID_PARAMS
+
+    def test_invalid_tenant_id(self, server: MCPServer) -> None:
+        resp = _call(server, "task_execute", {
+            "tenant_id": "",
+            "goal": "echo: hi",
+        })
+        assert resp["error"]["code"] == ERR_INVALID_PARAMS
+
+
+class TestTaskExecuteTimeout:
+    def test_timeout_returns_status_no_exception(self, server: MCPServer) -> None:
+        from riks_context_engine.tools.executor import build_default_registry
+
+        registry = build_default_registry()
+        registry.register(SlowTool())
+        server.handler._tool_registry = registry
+
+        t0 = time.monotonic()
+        resp = _call(server, "task_execute", {
+            "tenant_id": "t-timeout",
+            "goal": "slow: x",
+            "timeout": 1,
+        })
+        elapsed = time.monotonic() - t0
+
+        content = json.loads(resp["result"]["content"][0]["text"])
+        assert content["status"] == "timeout"
+        assert content["result"] is None
+        assert elapsed < 2.0
+
+    def test_post_timeout_ping(self, server: MCPServer) -> None:
+        from riks_context_engine.tools.executor import build_default_registry
+
+        registry = build_default_registry()
+        registry.register(SlowTool())
+        server.handler._tool_registry = registry
+
+        _call(server, "task_execute", {
+            "tenant_id": "t-timeout2",
+            "goal": "slow: x",
+            "timeout": 1,
+        })
+
+        ping_req = {"jsonrpc": "2.0", "id": 99, "method": "ping"}
+        ping_resp = json.loads(server.dispatch(ping_req))
+        assert ping_resp["result"]["pong"] is True
+
+    def test_timeout_clamped_to_120(self, server: MCPServer) -> None:
+        resp = _call(server, "task_execute", {
+            "tenant_id": "t-test",
+            "goal": "echo: fast",
+            "timeout": 9999,
+        })
+        assert resp["error"]["code"] == ERR_INVALID_PARAMS
+
+
+class TestTaskExecuteTenantIsolation:
+    def test_tenant_scoped_queue(self, server: MCPServer, tmp_path: Path) -> None:
+        _call(server, "task_execute", {
+            "tenant_id": "agentA",
+            "goal": "echo: secret",
+        })
+
+        a_tasks = tmp_path / "data" / "tenants" / "agentA" / "tasks.json"
+        assert a_tasks.exists()
+        data = json.loads(a_tasks.read_text())
+        task = data["tasks"][0]
+        assert task["owner_tenant"] == "agentA"
+        assert task["status"] == "done"
+
+        b_tasks = tmp_path / "data" / "tenants" / "agentB" / "tasks.json"
+        assert not b_tasks.exists()
+
+
+class TestVersionConsistency:
+    def test_server_info_version(self) -> None:
+        assert SERVER_INFO["version"] == "0.3.0"
+
+    def test_health_check_matches_server_info(self, server: MCPServer) -> None:
+        result = server.handler.health_check({})
+        assert result["version"] == SERVER_INFO["version"]
+
+    def test_init_response_version(self, server: MCPServer) -> None:
+        resp = server.handle_initialize({})
+        assert resp["serverInfo"]["version"] == "0.3.0"
+
+
+class TestToolsList:
+    def test_nine_tools(self, server: MCPServer) -> None:
+        result = server.handle_tools_list()
+        names = {t["name"] for t in result["tools"]}
+        assert len(names) == 9
+        assert "task_execute" in names
+        assert "semantic_write" in names


### PR DESCRIPTION
## Değişiklikler
- Yeni MCP tool: `task_execute` (tenant_id, goal, timeout)
- Timeout zorunlu, max 120s — aşılırsa `{status: timeout}` döner (exception yok)
- Hata yolları: ToolExecutionError → -32602, beklenmeyen → -32603
- `task_queue_path(tenant_id=None, data_dir=None)` imza değişikliği
- SERVER_INFO → 0.3.0, health_check tutarlılığı
- tools/list → 9 tool (7 mevcut + semantic_write + task_execute)
- #108 merge sonrası rebase edildi

## Test
- `tests/test_mcp_task_execute.py`: echo, bilinmeyen tool, boş goal, timeout, post-timeout ping, tenant isolation, version consistency, 9 tool count
- Tüm mevcut testler regresyon kontrolü (623 passed)
- ruff + mypy temiz

## Bilinen Sınır
- Timeout sonrası orphan thread birikimi → takip issue açıldı

Closes #107