### PR TITLE
test: make orphan-thread timeout tests deterministic (follow-up to #154)

### DIFF
--- a/src/riks_context_engine/tools/executor.py
+++ b/src/riks_context_engine/tools/executor.py
@@ -10,16 +10,74 @@ A *task* is a goal (string) that, when executed, is dispatched to a *tool*
 Execution runs in a worker thread so a hard timeout can be enforced. A
 goal that is not a string (or a tool that raises) propagates as
 ``ToolExecutionError``.
+
+Timeout semantics (orphan-thread cleanup, #151):
+
+A timeout *cannot* force-terminate a running Python thread (there is no
+safe ``Thread.kill``); ``concurrent.futures.Future.cancel()`` would not
+stop a worker that is already running either. Instead ``execute_goal``
+uses **cooperative cancellation**: it sets a module-level
+``threading.Event`` (``get_stop_event``) once the timeout window elapses
+and then waits for the worker to finish with a bounded
+``join(_ORPHAN_GRACE_SECONDS)``.
+
+Well-behaved tools (and any loop / long tool call that periodically
+consults the stop event) see ``stop_event.is_set()`` and return
+promptly, so the worker thread always terminates and **no orphan thread
+is left behind**. Tools that ignore the event (e.g. a blocking C call)
+are joined for a short grace period (``_ORPHAN_GRACE_SECONDS``) only;
+if the thread is still alive it is logged and counted by
+``get_orphan_thread_count()`` — a bounded diagnostic, not an unbounded
+leak. See ``tests/test_orphan_thread_151.py`` for the deterministic
+coverage (baseline restore, no-leak regression, normal-path
+invariance).
 """
 
 from __future__ import annotations
 
+import logging
 import threading
 from dataclasses import dataclass
 from typing import Any
 
 from riks_context_engine.tools.base_tool import ToolRegistry
 from riks_context_engine.tools.echo_tool import EchoTool
+
+logger = logging.getLogger(__name__)
+
+# How long (seconds) to join a still-running worker thread after its
+# timeout window elapses, before giving up and logging it as an orphan.
+# Bounded: a misbehaving tool cannot block the caller indefinitely. Kept
+# short so an uncooperative tool cannot delay the caller by the full grace
+# period (the MCP server, for example, promises a sub-2 s response).
+_ORPHAN_GRACE_SECONDS = 0.5
+
+# Cooperative cancellation state, shared with worker threads.
+_stop_event = threading.Event()
+_stop_event_lock = threading.Lock()
+_orphan_thread_count = 0
+
+
+def get_stop_event() -> threading.Event:
+    """Return the cooperative-cancellation event.
+
+    Tools and worker loops may consult ``is_set()`` periodically to stop
+    early when a timeout fires (see module docstring). A fresh, cleared
+    event is returned on every :func:`execute_goal` call.
+    """
+    return _stop_event
+
+
+def get_orphan_thread_count() -> int:
+    """Return the number of worker threads that outlived their join grace
+    period (a diagnostic counter, see module docstring)."""
+    return _orphan_thread_count
+
+
+def _reset_orphan_thread_count() -> None:
+    """Test helper: reset the orphan counter to zero."""
+    global _orphan_thread_count
+    _orphan_thread_count = 0
 
 
 class ToolExecutionError(Exception):
@@ -104,7 +162,16 @@ def execute_goal(
     Returns an :class:`ExecutionResult`. Raises ``ToolExecutionError`` on a
     bad goal / unknown tool / tool error. A ``timeout`` (seconds) that
     elapses before the tool returns yields ``timed_out=True``.
+
+    Timeout path (cooperative cancellation, #151): once the window elapses
+    the module-level stop event (``get_stop_event()``) is set and the worker
+    thread is joined with a short, bounded grace period. Well-behaved tools
+    observe the event and return promptly, so no orphan thread is left
+    behind; a thread that ignores the event is logged and counted (see
+    module docstring and ``tests/test_orphan_thread_151.py``).
     """
+    global _orphan_thread_count
+
     try:
         name, params = parse_goal(goal, registry)
     except KeyError as exc:
@@ -113,6 +180,10 @@ def execute_goal(
     tool = registry.get(name)
 
     holder: dict[str, Any] = {}
+
+    # Reset cooperative-cancellation state for this call.
+    with _stop_event_lock:
+        _stop_event.clear()
 
     def _run() -> None:
         try:
@@ -125,7 +196,22 @@ def execute_goal(
     worker.join(timeout)
 
     if worker.is_alive():
-        # Timeout: the tool has not returned within the window.
+        # Timeout: the tool has not returned within the window. Signal
+        # cooperative cancellation, then wait a bounded grace period for
+        # the (well-behaved) tool to observe the event and finish.
+        with _stop_event_lock:
+            _stop_event.set()
+        worker.join(_ORPHAN_GRACE_SECONDS)
+        if worker.is_alive():
+            # The tool ignored the stop event (e.g. blocking C call).
+            # Count it as an orphan for diagnostics; we do not block.
+            _orphan_thread_count += 1
+            logger.warning(
+                "task_execute: worker thread for tool %r outlived its join grace "
+                "period after a timeout and may outlive this process (orphan #%d)",
+                name,
+                _orphan_thread_count,
+            )
         return ExecutionResult(result="", timed_out=True)
 
     if "error" in holder:

--- a/tests/test_orphan_thread_151.py
+++ b/tests/test_orphan_thread_151.py
@@ -14,9 +14,11 @@ orphan thread is left behind**.
 
 Deterministic coverage (acceptance criteria, #151)
 --------------------------------------------------
-1. After a timeout the active worker thread returns to the baseline count
-   (``threading.enumerate()``) within the tool's own observation cadence —
-   asserted against a slow-but-cooperative mock tool (no wall-clock races).
+1. After a timeout the worker thread is gone and the active thread count
+   returns to the baseline — asserted against a slow-but-cooperative mock
+   tool whose sleeps are ``stop_event.wait(slice)`` (woken instantly when
+   the timeout fires the event) — and cross-validated with a *named*
+   worker thread. No wall-clock races.
 2. The normal (pre-timeout) path is unchanged: results and behaviour match
    the original ``execute_goal`` contract.
 3. No thread leak: 10 consecutive timeout calls leave the active thread
@@ -41,13 +43,23 @@ from riks_context_engine.tools.executor import (
 
 
 def _worker_threads() -> int:
-    """Count non-main worker threads (the baseline is 0)."""
+    """Count non-main worker threads (the baseline is 0 in-process)."""
     return len(threading.enumerate())
 
 
-# A fast cooperative worker: returns immediately, but only once the stop
-# event has been observed as set. Used to *prove* the event fires without
-# relying on a wall-clock race.
+def _wait_until(predicate: Any, timeout: float = 5.0) -> None:
+    """Deterministically wait until ``predicate()`` is true (bounded)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    assert predicate(), f"condition not met within {timeout}s"
+
+
+# A fast cooperative worker: returns as soon as the stop event is set.
+# Used to *prove* the event fires — ``stop_event.wait(20)`` returns
+# immediately once the timeout has set the event (no wall-clock race).
 class StopProbeTool(Tool):
     name = "stop-probe"
     description = "Returns once the stop event is observed as set."
@@ -58,17 +70,13 @@ class StopProbeTool(Tool):
     }
 
     def execute(self, params: dict[str, Any]) -> str:
-        deadline = time.monotonic() + 20.0
-        while time.monotonic() < deadline:
-            if executor.get_stop_event().is_set():
-                return "stopped"
-            time.sleep(0.001)
-        return "not-stopped"
+        return "stopped" if executor.get_stop_event().wait(20.0) else "not-stopped"
 
 
-# A slow-but-cooperative worker: polls the stop event every 10 ms and
-# returns as soon as it is set. Emulates a real long tool call (llm_call,
-# web_fetch, file_read) that checks for cancellation between steps.
+# A slow-but-cooperative worker: sleeps in small slices via
+# ``stop_event.wait(slice)`` — which returns immediately when the timeout
+# fires the event. Emulates a real long tool call (llm_call, web_fetch,
+# file_read) that checks for cancellation between steps.
 class SlowCooperativeTool(Tool):
     name = "slow-coop"
     description = "Sleeps in small slices, returning when the stop event is set."
@@ -88,7 +96,7 @@ class SlowCooperativeTool(Tool):
         while elapsed < self.total:
             if stop.is_set():
                 return "cancelled"
-            time.sleep(self.slice)
+            stop.wait(self.slice)
             elapsed += self.slice
         return "finished"
 
@@ -107,7 +115,7 @@ class UncooperativeTool(Tool):
         self.duration = duration
 
     def execute(self, params: dict[str, Any]) -> str:
-        time.sleep(self.duration)
+        threading.Event().wait(self.duration)
         return "too-late"
 
 
@@ -151,7 +159,8 @@ class TestCooperativeCancellation:
 
     def test_stop_event_fires_on_timeout(self):
         """The stop event is set by the timeout (proven via a fast probe,
-        without a wall-clock race)."""
+        no wall-clock race: ``stop_event.wait(20)`` returns instantly once
+        the event is set by the timeout)."""
         registry = build_default_registry()
         registry.register(StopProbeTool())
         result = execute_goal("stop-probe: x", registry, timeout=0.05)
@@ -159,8 +168,9 @@ class TestCooperativeCancellation:
         assert result.result == ""
 
     def test_worker_thread_returns_to_baseline(self):
-        """A slow-but-cooperative tool returns to the baseline thread count
-        shortly after the timeout (deterministic: the tool polls every 10 ms)."""
+        """A slow-but-cooperative tool's worker thread is gone shortly
+        after the timeout (deterministic: the tool wakes on the stop
+        event), so the thread count returns to baseline."""
         executor._reset_orphan_thread_count()
         baseline = _worker_threads()
         registry = build_default_registry()
@@ -168,13 +178,30 @@ class TestCooperativeCancellation:
         result = execute_goal("slow-coop: x", registry, timeout=0.2)
         assert result.timed_out is True
 
-        # Wait (deterministically) for the worker to observe the event and
-        # finish — bounded well under the grace period.
-        deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline and _worker_threads() > baseline:
-            time.sleep(0.01)
+        _wait_until(lambda: _worker_threads() == baseline)
         assert _worker_threads() == baseline
         assert executor.get_orphan_thread_count() == 0
+
+    def test_named_worker_is_gone_after_timeout(self):
+        """Cross-validation with a directly-controlled worker thread:
+        after the timeout the stop event is set, the cooperative worker
+        finishes (``Event.wait`` wakes on it) and its ``is_alive()`` flips
+        to False — no orphan, independent of any other threads."""
+        tool = SlowCooperativeTool(total=5.0, slice=0.01)
+        with executor._stop_event_lock:
+            executor._stop_event.clear()
+
+        def _run() -> None:
+            tool.execute({})
+
+        worker = threading.Thread(target=_run, name="test-orphan-worker", daemon=True)
+        worker.start()
+        worker.join(0.2)  # the timeout window
+        assert worker.is_alive()
+        with executor._stop_event_lock:
+            executor._stop_event.set()
+        worker.join(executor._ORPHAN_GRACE_SECONDS)
+        assert not worker.is_alive()
 
     def test_no_thread_leak_10_consecutive_timeouts(self):
         """Acceptance criterion 3: 10 consecutive timeouts leave the active
@@ -187,11 +214,10 @@ class TestCooperativeCancellation:
         for _ in range(10):
             result = execute_goal("slow-coop: x", registry, timeout=0.05)
             assert result.timed_out is True
+            # Deterministically wait for this worker to finish before the
+            # next call (keeps the count assertion tight and race-free).
+            _wait_until(lambda: _worker_threads() == baseline)
 
-        # Deterministically wait for all workers to finish.
-        deadline = time.monotonic() + 5.0
-        while time.monotonic() < deadline and _worker_threads() > baseline:
-            time.sleep(0.01)
         assert _worker_threads() == baseline
         assert executor.get_orphan_thread_count() == 0
 
@@ -201,15 +227,21 @@ class TestUncooperativeToolBounded:
 
     def test_orphan_counted_and_bounded(self, monkeypatch: pytest.MonkeyPatch):
         executor._reset_orphan_thread_count()
+        # Deterministic: shrink the grace period below the worker's own
+        # lifetime, so the grace join is *guaranteed* to time out — no
+        # wall-clock race, no real-time.sleep after the call (and hence no
+        # teardown-time sqlite3/SystemError shutdown spam). The worker is
+        # then joined explicitly below.
+        monkeypatch.setattr(executor, "_ORPHAN_GRACE_SECONDS", 0.2)
         baseline = _worker_threads()
         registry = build_default_registry()
-        registry.register(UncooperativeTool(duration=5.0))
+        registry.register(UncooperativeTool(duration=0.3))
 
         result = execute_goal("uncoop: x", registry, timeout=0.05)
         assert result.timed_out is True
         # The misbehaving thread is counted (diagnostic), not unbounded.
         assert executor.get_orphan_thread_count() == 1
 
-        # Let the (5 s) tool finish so the test process is left clean.
-        time.sleep(5.0)
+        # Deterministically wait for the (0.3 s) worker to finish.
+        _wait_until(lambda: _worker_threads() == baseline)
         assert _worker_threads() == baseline

--- a/tests/test_orphan_thread_151.py
+++ b/tests/test_orphan_thread_151.py
@@ -1,0 +1,215 @@
+"""Orphan-thread cleanup after ``task_execute`` timeout (issue #151).
+
+Background
+----------
+``execute_goal`` enforces a timeout by running the tool in a worker thread.
+A timeout cannot force-terminate a running Python thread, so the worker is
+*cooperatively* cancelled: once the timeout window elapses ``execute_goal``
+sets the module-level stop event (``get_stop_event()``) and then joins the
+worker with a bounded grace period.
+
+A **well-behaved** tool observes the stop event in its loop / long tool
+call and returns promptly, so the worker thread always terminates and **no
+orphan thread is left behind**.
+
+Deterministic coverage (acceptance criteria, #151)
+--------------------------------------------------
+1. After a timeout the active worker thread returns to the baseline count
+   (``threading.enumerate()``) within the tool's own observation cadence —
+   asserted against a slow-but-cooperative mock tool (no wall-clock races).
+2. The normal (pre-timeout) path is unchanged: results and behaviour match
+   the original ``execute_goal`` contract.
+3. No thread leak: 10 consecutive timeout calls leave the active thread
+   count at baseline (regression test).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from riks_context_engine.tools import executor
+from riks_context_engine.tools.base_tool import Tool
+from riks_context_engine.tools.executor import (
+    ToolExecutionError,
+    build_default_registry,
+    execute_goal,
+)
+
+
+def _worker_threads() -> int:
+    """Count non-main worker threads (the baseline is 0)."""
+    return len(threading.enumerate())
+
+
+# A fast cooperative worker: returns immediately, but only once the stop
+# event has been observed as set. Used to *prove* the event fires without
+# relying on a wall-clock race.
+class StopProbeTool(Tool):
+    name = "stop-probe"
+    description = "Returns once the stop event is observed as set."
+    parameters = {
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+    }
+
+    def execute(self, params: dict[str, Any]) -> str:
+        deadline = time.monotonic() + 20.0
+        while time.monotonic() < deadline:
+            if executor.get_stop_event().is_set():
+                return "stopped"
+            time.sleep(0.001)
+        return "not-stopped"
+
+
+# A slow-but-cooperative worker: polls the stop event every 10 ms and
+# returns as soon as it is set. Emulates a real long tool call (llm_call,
+# web_fetch, file_read) that checks for cancellation between steps.
+class SlowCooperativeTool(Tool):
+    name = "slow-coop"
+    description = "Sleeps in small slices, returning when the stop event is set."
+    parameters = {
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+    }
+
+    def __init__(self, total: float = 5.0, slice: float = 0.01) -> None:
+        self.total = total
+        self.slice = slice
+
+    def execute(self, params: dict[str, Any]) -> str:
+        stop = executor.get_stop_event()
+        elapsed = 0.0
+        while elapsed < self.total:
+            if stop.is_set():
+                return "cancelled"
+            time.sleep(self.slice)
+            elapsed += self.slice
+        return "finished"
+
+
+# A misbehaving worker: never checks the stop event (blocking C call).
+class UncooperativeTool(Tool):
+    name = "uncoop"
+    description = "Sleeps without checking the stop event."
+    parameters = {
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+    }
+
+    def __init__(self, duration: float) -> None:
+        self.duration = duration
+
+    def execute(self, params: dict[str, Any]) -> str:
+        time.sleep(self.duration)
+        return "too-late"
+
+
+class TestNormalPathUnchanged:
+    """Acceptance criterion 2: the pre-timeout path is unchanged."""
+
+    def test_echo_result(self):
+        registry = build_default_registry()
+        result = execute_goal("echo: merhaba", registry)
+        assert result.result == "merhaba"
+        assert result.timed_out is False
+
+    def test_default_tool_no_colon(self):
+        registry = build_default_registry()
+        result = execute_goal("just a plain goal", registry)
+        assert result.result == "just a plain goal"
+        assert result.timed_out is False
+
+    def test_tool_error_propagates(self):
+        class Boom(Tool):
+            name = "boom"
+            description = "Always raises."
+            parameters = {"type": "object", "properties": {"text": {"type": "string"}}}
+
+            def execute(self, params: dict[str, Any]) -> str:
+                raise ValueError("boom")
+
+        registry = build_default_registry()
+        registry.register(Boom())
+        with pytest.raises(ToolExecutionError, match="boom"):
+            execute_goal("boom: x", registry)
+
+    def test_unknown_tool_rejected(self):
+        registry = build_default_registry()
+        with pytest.raises(ToolExecutionError, match="unknown tool"):
+            execute_goal("nope: x", registry)
+
+
+class TestCooperativeCancellation:
+    """Acceptance criterion 1: the worker returns to baseline after timeout."""
+
+    def test_stop_event_fires_on_timeout(self):
+        """The stop event is set by the timeout (proven via a fast probe,
+        without a wall-clock race)."""
+        registry = build_default_registry()
+        registry.register(StopProbeTool())
+        result = execute_goal("stop-probe: x", registry, timeout=0.05)
+        assert result.timed_out is True
+        assert result.result == ""
+
+    def test_worker_thread_returns_to_baseline(self):
+        """A slow-but-cooperative tool returns to the baseline thread count
+        shortly after the timeout (deterministic: the tool polls every 10 ms)."""
+        executor._reset_orphan_thread_count()
+        baseline = _worker_threads()
+        registry = build_default_registry()
+        registry.register(SlowCooperativeTool(total=5.0, slice=0.01))
+        result = execute_goal("slow-coop: x", registry, timeout=0.2)
+        assert result.timed_out is True
+
+        # Wait (deterministically) for the worker to observe the event and
+        # finish — bounded well under the grace period.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and _worker_threads() > baseline:
+            time.sleep(0.01)
+        assert _worker_threads() == baseline
+        assert executor.get_orphan_thread_count() == 0
+
+    def test_no_thread_leak_10_consecutive_timeouts(self):
+        """Acceptance criterion 3: 10 consecutive timeouts leave the active
+        thread count at baseline (regression test)."""
+        executor._reset_orphan_thread_count()
+        baseline = _worker_threads()
+        registry = build_default_registry()
+        registry.register(SlowCooperativeTool(total=10.0, slice=0.01))
+
+        for _ in range(10):
+            result = execute_goal("slow-coop: x", registry, timeout=0.05)
+            assert result.timed_out is True
+
+        # Deterministically wait for all workers to finish.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and _worker_threads() > baseline:
+            time.sleep(0.01)
+        assert _worker_threads() == baseline
+        assert executor.get_orphan_thread_count() == 0
+
+
+class TestUncooperativeToolBounded:
+    """A tool that ignores the stop event is bounded by the grace period."""
+
+    def test_orphan_counted_and_bounded(self, monkeypatch: pytest.MonkeyPatch):
+        executor._reset_orphan_thread_count()
+        baseline = _worker_threads()
+        registry = build_default_registry()
+        registry.register(UncooperativeTool(duration=5.0))
+
+        result = execute_goal("uncoop: x", registry, timeout=0.05)
+        assert result.timed_out is True
+        # The misbehaving thread is counted (diagnostic), not unbounded.
+        assert executor.get_orphan_thread_count() == 1
+
+        # Let the (5 s) tool finish so the test process is left clean.
+        time.sleep(5.0)
+        assert _worker_threads() == baseline


### PR DESCRIPTION
Follow-up to #154 (merged 0c97b016). Commit 71e5e97: makes the orphan-thread timeout tests deterministic by removing wall-clock races (CI flake prevention). No code change beyond the test file.

Pushed by Rik (heartbeat automation) on 2026-08-20 11:44 — this was the one outstanding unpushed commit from the completed project.