### PR TITLE
feat(staging): single-command lifecycle, CI image source, persistence guards [P2] (#159)

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,70 @@
+# ===== Base ===== #
+# Pinned by digest (2026-08-17, #117): the floating 3.12-slim tag moved to
+# Debian 13.6 on 2026-08-16 and introduced new HIGH findings that the
+# pinned digest predates. Re-pin deliberately (record old+new digest here)
+# instead of drifting silently.
+#
+# Multi-arch pin (2026-08-20, #156): #117 pinned the *amd64* digest only,
+# which broke `docker build` on arm64 hosts with "exec format error"
+# (QEMU/binfmt not registered). The base is now pinned PER ARCHITECTURE
+# (same digest-pinning discipline, both arches of the same 3.12-slim
+# image, Docker Hub manifest list last_updated 2026-08-16T20:07Z):
+#
+#   linux/amd64  sha256:876416ecde9aca2bcc90e1fb0c7a9500bbf749f5788b70f82d4c5a5c2357f8b4  (unchanged from #117 — CI amd64 build stays byte-identical)
+#   linux/arm64  sha256:0568e6111802e74c03e8dda76565cdf4b88881d77de0d9b769846e9dfcb8d80a  (added for arm64 hosts)
+#
+# Why per-arch pins (option a, not buildx manifest publish): the CI/CD
+# amd64 path is unchanged — the amd64 digest is the exact one from #117 —
+# and arm64 hosts build natively, no QEMU. A future re-pin (#117) must
+# update BOTH digests — the one in the FROM line below AND the one in
+# scripts/gen_dockerfile_arm64.py (used by the cd.yml arm64-build job) —
+# and record old+new here.
+#
+# This checked-in file is the amd64 variant (CI/CD builds it as-is).
+# GENERATED-FOR-ARCH:arm64
+# arm64 hosts / CI arm64 check: generate the arm64 variant with
+# `scripts/gen_dockerfile_arm64.py` (rewrites the pinned digest) and build
+# that; cd.yml's arm64-build job (buildx, push=false) proves the arm64
+# image builds.
+FROM python:3.12-slim@sha256:0568e6111802e74c03e8dda76565cdf4b88881d77de0d9b769846e9dfcb8d80a
+
+LABEL maintainer="vopsiton <vahit@opsiton.com>"
+LABEL description="Rik's Context Engine - AI memory and context management"
+LABEL org.opencontainers.image.base.name="python:3.12-slim (digest-pinned per architecture, #117 + #156)"
+LABEL org.opencontainers.image.created.arch="arm64"
+
+WORKDIR /app
+
+# ===== Dependencies ===== #
+# Upgrade all OS packages to the latest available (security backports).
+# Combined with the digest pin above this keeps the OS surface as small
+# as the base image allows; remaining unfixed CVEs are documented in
+# .github/trivy-exceptions.yaml with review dates.
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy app source (needed for editable install)
+COPY src/ ./src/
+COPY tests/ ./tests/
+COPY ui/ ./ui/
+
+# Copy and install
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir -e ".[dev]"
+
+# ===== Data directory ===== #
+RUN mkdir -p /app/data && chmod 755 /app/data
+
+ENV PYTHONPATH=/app/src
+ENV DATA_DIR=/app/data
+ENV UI_PATH=/app/ui/index.html
+
+# Default port
+EXPOSE 8000
+
+# Default command - run uvicorn server
+CMD ["python", "-m", "uvicorn", "riks_context_engine.api.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -7,9 +7,13 @@ services:
   staging:
     profiles:
       - staging
-    build:
-      context: .
-      dockerfile: Dockerfile
+    # No `build:` section on purpose (#159): the image is the CI-published
+    # one, pulled/retagged to `riks-context-engine:staging` by
+    # scripts/staging.sh start (GHCR `staging-<sha>` resolution +
+    # drift-guarded local-build fallback). Without a build: section, compose
+    # uses the local image and fails fast (pull: missing) instead of
+    # silently re-building with the checked-in amd64 Dockerfile on an arm64
+    # host (the 'exec format error' root cause, AC5).
     image: riks-context-engine:staging
     container_name: riks-context-engine-staging
     environment:

--- a/scripts/lib/staging-common.sh
+++ b/scripts/lib/staging-common.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# =============================================================================
+# riks-context-engine — Staging shared helpers (source, do not execute)
+# =============================================================================
+# Shared by scripts/staging.sh and scripts/test-staging.sh (#159).
+#
+# Provides:
+#   - GHCR image resolution: staging-<sha> tag from STAGING_SHA env (priority),
+#     then `git rev-parse --short HEAD`, then the `staging` floating tag
+#     (with a warning) — so local pulls match what CI (cd.yml deploy-staging)
+#     actually pushes (ghcr.io/vopsiton/riks-context-engine:staging-<sha>).
+#   - host-arch detection (linux/amd64 | linux/arm64)
+#   - local-build fallback with a digest-drift guard (AC5): regenerate
+#     Dockerfile.arm64 from scripts/gen_dockerfile_arm64.py, diff it against
+#     the committed file, and FAIL on drift (same guard as cd.yml
+#     arm64-build job) — never build on an arm64 host with the amd64
+#     (checked-in) Dockerfile.
+#
+# Sourced functions read: nothing global. They write (export when called):
+#   RESOLVED_IMAGE, RESOLVED_TAG, STAGING_SHA_SOURCE, HOST_ARCH, GHCR_REPO
+# =============================================================================
+
+STAGING_GHCR_REPO="ghcr.io/vopsiton/riks-context-engine"
+STAGING_LOCAL_IMAGE="riks-context-engine:staging"
+
+# Detect the host architecture as a linux/<arch> docker platform.
+detect_host_arch() {
+    local uname_m
+    uname_m="$(uname -m)"
+    case "$uname_m" in
+        aarch64 | arm64) HOST_ARCH="linux/arm64" ;;
+        x86_64)          HOST_ARCH="linux/amd64" ;;
+        *)
+            echo "ERROR: unsupported host architecture '${uname_m}'." >&2
+            return 1
+            ;;
+    esac
+}
+
+# Resolve the staging image tag CI would have published (#159).
+# Source order:
+#   (a) $STAGING_SHA env var (explicit, priority)
+#   (b) git rev-parse --short HEAD (when inside a git work tree)
+#   (c) floating `staging` tag (fallback, with warning)
+# Sets: RESOLVED_IMAGE, RESOLVED_TAG, STAGING_SHA_SOURCE.
+resolve_staging_image() {
+    local sha="" source=""
+    if [ -n "${STAGING_SHA:-}" ]; then
+        sha="$STAGING_SHA"
+        source="STAGING_SHA env"
+    elif sha="$(git rev-parse --short HEAD 2>/dev/null)" && [ -n "$sha" ]; then
+        source="git rev-parse --short HEAD"
+    fi
+
+    if [ -n "$sha" ]; then
+        RESOLVED_TAG="staging-${sha}"
+        RESOLVED_IMAGE="${STAGING_GHCR_REPO}:${RESOLVED_TAG}"
+        STAGING_SHA_SOURCE="$source"
+    else
+        RESOLVED_TAG="staging"
+        RESOLVED_IMAGE="${STAGING_GHCR_REPO}:${RESOLVED_TAG}"
+        STAGING_SHA_SOURCE="fallback"
+        echo "WARNING: no SHA source (STAGING_SHA unset, not a git work tree)." >&2
+        echo "  Falling back to the floating '${RESOLVED_TAG}' tag — it may not" >&2
+        echo "  match the commit CI last deployed. Set STAGING_SHA to be exact." >&2
+    fi
+}
+
+# Ensure Dockerfile.arm64 matches what scripts/gen_dockerfile_arm64.py
+# generates from the checked-in (amd64) Dockerfile. Exits non-zero on
+# drift or generation failure (same guard as the cd.yml arm64-build job).
+# Keeps the working-tree file untouched (compares against a temp file).
+check_arm64_dockerfile_sync() {
+    local gen
+    gen="$(mktemp)" || return 1
+    if ! python3 scripts/gen_dockerfile_arm64.py Dockerfile > "$gen" 2>/dev/null; then
+        rm -f "$gen"
+        echo "ERROR: scripts/gen_dockerfile_arm64.py failed to generate the" >&2
+        echo "  arm64 variant (digest drift between Dockerfile and the pinned" >&2
+        echo "  digests?). Re-pin per #117 and regenerate before building." >&2
+        return 1
+    fi
+    if ! diff -u Dockerfile.arm64 "$gen" >/dev/null; then
+        rm -f "$gen"
+        echo "ERROR: Dockerfile.arm64 has drifted from scripts/gen_dockerfile_arm64.py" >&2
+        echo "  (digest-sync guard, AC5). Regenerate and commit:" >&2
+        echo "    python3 scripts/gen_dockerfile_arm64.py Dockerfile > Dockerfile.arm64" >&2
+        return 1
+    fi
+    rm -f "$gen"
+    return 0
+}
+
+# Local-build fallback for when the GHCR pull fails (AC5):
+#   - NEVER build with the checked-in amd64 Dockerfile on an arm64 host
+#     (that is the root cause of 'exec format error').
+#   - arm64 host: drift-guard Dockerfile.arm64, then native build.
+#   - amd64 host: build with the checked-in Dockerfile.
+# Tags the result with $STAGING_LOCAL_IMAGE so compose uses it.
+local_build_fallback() {
+    if [ "$HOST_ARCH" = "linux/arm64" ]; then
+        if [ ! -f Dockerfile.arm64 ]; then
+            echo "ERROR: Dockerfile.arm64 not found (expected committed in #159)." >&2
+            return 1
+        fi
+        if ! check_arm64_dockerfile_sync; then
+            return 1
+        fi
+        echo "==> Local build (arm64, native, -f Dockerfile.arm64):"
+        docker build --platform linux/arm64 -f Dockerfile.arm64 -t "$STAGING_LOCAL_IMAGE" .
+    else
+        echo "==> Local build (amd64, -f Dockerfile):"
+        docker build --platform linux/amd64 -f Dockerfile -t "$STAGING_LOCAL_IMAGE" .
+    fi
+}
+
+# --rebuild path (#159): force a local build for the host arch, skipping
+# the CI image entirely (drift-guarded on arm64 hosts — AC5).
+ensure_staging_image_force_rebuild() {
+    detect_host_arch
+    echo "==> --rebuild: building ${STAGING_LOCAL_IMAGE} locally for ${HOST_ARCH} (skipping CI pull)."
+    local_build_fallback
+}
+
+# Ensure the staging image is available locally, preferring the CI image:
+#   1. CI image present locally ($RESOLVED_IMAGE) → retag to
+#      $STAGING_LOCAL_IMAGE for compose.
+#   2. otherwise docker pull --platform (CI image) → retag.
+#   3. otherwise $STAGING_LOCAL_IMAGE present locally → use it (warning).
+#   4. otherwise local build fallback (drift-guarded, arch-correct).
+ensure_staging_image() {
+    detect_host_arch
+    resolve_staging_image
+    echo "==> Resolved staging image: ${RESOLVED_IMAGE} (${STAGING_SHA_SOURCE}, ${HOST_ARCH})"
+
+    if docker image inspect "$RESOLVED_IMAGE" >/dev/null 2>&1; then
+        echo "==> Using local CI image ${RESOLVED_IMAGE}."
+        docker tag "$RESOLVED_IMAGE" "$STAGING_LOCAL_IMAGE"
+        return 0
+    fi
+
+    echo "==> Pulling ${RESOLVED_IMAGE} (${HOST_ARCH})..."
+    if docker pull --platform "$HOST_ARCH" "$RESOLVED_IMAGE" 2>/dev/null; then
+        docker tag "$RESOLVED_IMAGE" "$STAGING_LOCAL_IMAGE"
+        return 0
+    fi
+    echo "WARNING: GHCR pull failed for ${RESOLVED_IMAGE} (network/permissions/tag not published?)." >&2
+
+    if docker image inspect "$STAGING_LOCAL_IMAGE" >/dev/null 2>&1; then
+        echo "WARNING: using pre-existing local image ${STAGING_LOCAL_IMAGE} (not the CI tag)." >&2
+        return 0
+    fi
+
+    echo "==> No local image available — falling back to local build." >&2
+    local_build_fallback
+}

--- a/scripts/staging.sh
+++ b/scripts/staging.sh
@@ -12,13 +12,25 @@
 # binary as fallback (detected via `command -v`).
 #
 # STAGING_API_URL is read from .env.staging (default http://localhost:8001).
+#
+# Shared helpers (GHCR staging-<sha> resolution, host-arch detection,
+# drift-guarded local-build fallback) live in scripts/lib/staging-common.sh
+# and are shared with scripts/test-staging.sh (#159).
 # =============================================================================
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_DIR"
+
 STAGING_CONTAINER="riks-context-engine-staging"
 ENV_FILE=".env.staging"
 ENV_EXAMPLE=".env.staging.example"
+STAGING_DATA_VOLUME="staging-data"
+
+# shellcheck source=scripts/lib/staging-common.sh
+. "$SCRIPT_DIR/lib/staging-common.sh"
 
 # ── Compose resolver (plugin first, legacy fallback) ─────────────────────────
 
@@ -63,44 +75,50 @@ compose_up() {
     $COMPOSE -f docker-compose.yml -f docker-compose.staging.yml --env-file "$ENV_FILE" --profile staging up -d
 }
 
+compose_down() {
+    # --profile staging: `down` without the profile only removes profile-less
+    # services (dev/prod) and leaves the staged container running.
+    $COMPOSE -f docker-compose.yml -f docker-compose.staging.yml --env-file "$ENV_FILE" --profile staging down 2>/dev/null || true
+}
+
 # ── Commands ─────────────────────────────────────────────────────────────────
 
 start_staging() {
+    local rebuild=0
+    for arg in "$@"; do
+        case "$arg" in
+            --rebuild)
+                rebuild=1
+                ;;
+            *)
+                echo "ERROR: unknown start option '${arg}' (usage: staging.sh start [--rebuild])" >&2
+                exit 1
+                ;;
+        esac
+    done
+
     resolve_compose
     resolve_staging_api_url
 
     echo "==> Starting staging environment (API: ${STAGING_API_URL})..."
 
+    if [ "$rebuild" -eq 1 ]; then
+        # --rebuild: skip the CI pull entirely; build locally for the host
+        # arch (arm64 hosts: Dockerfile.arm64 with drift guard — AC5).
+        ensure_staging_image_force_rebuild
+    fi
+
     if docker ps --format '{{.Names}}' | grep -q "^${STAGING_CONTAINER}$"; then
         echo "Staging container already running. Skipping up."
     else
-        # The image is built per-architecture by the CI/CD pipeline (#156:
-        # amd64 for CI, arm64 for arm64 hosts) and published to GHCR.
-        # A local `compose up` with `build:` would re-build for the host
-        # arch; on a host whose local images are a different arch this
-        # fails with 'exec format error'. Pull the host-arch image
-        # explicitly instead (the compose file's build: is only a fallback
-        # for local dev).
-        local host_arch
-        host_arch="$(uname -m)"
-        case "$host_arch" in
-            aarch64 | arm64) host_arch="arm64" ;;
-            x86_64) host_arch="amd64" ;;
-        esac
-        local ghcr_image="ghcr.io/vopsiton/riks-context-engine:staging"
-        echo "==> Pulling ${ghcr_image} (${host_arch})..."
-        if ! docker pull --platform "linux/${host_arch}" "$ghcr_image" 2>/dev/null; then
-            echo "WARNING: GHCR pull failed (network/permissions?). Falling back to local build."
-            echo "  Local build on arm64 hosts needs the arm64 Dockerfile variant:
-    python3 scripts/gen_dockerfile_arm64.py > Dockerfile.arm64
-    docker build --platform linux/arm64 -f Dockerfile.arm64 -t riks-context-engine:staging ."
-            if [ "$host_arch" = "arm64" ] && [ ! -f Dockerfile.arm64 ]; then
-                python3 scripts/gen_dockerfile_arm64.py > Dockerfile.arm64
-                docker build --platform linux/arm64 -f Dockerfile.arm64 -t riks-context-engine:staging .
-            else
-                $COMPOSE -f docker-compose.yml -f docker-compose.staging.yml --env-file "$ENV_FILE" build staging || true
-            fi
-        fi
+        # The image is built per-architecture by the CI/CD pipeline (#156)
+        # and published to GHCR as `staging-<sha>` (cd.yml deploy-staging).
+        # Resolution order (#159): STAGING_SHA env → git HEAD short sha →
+        # floating `staging` tag (warning). Never let compose re-build from
+        # the checked-in amd64 Dockerfile on an arm64 host (exec format
+        # error): the compose file no longer has a build: section, and the
+        # fallback path here builds with the arch-correct Dockerfile.
+        ensure_staging_image
         compose_up
     fi
 
@@ -125,20 +143,37 @@ start_staging() {
 }
 
 stop_staging() {
+    local purge=0
+    for arg in "$@"; do
+        case "$arg" in
+            --purge)
+                purge=1
+                ;;
+            *)
+                echo "ERROR: unknown stop option '${arg}' (usage: staging.sh stop [--purge])" >&2
+                exit 1
+                ;;
+        esac
+    done
+
     resolve_compose
     echo "==> Stopping staging environment..."
-    # Note: --volumes would destroy the staging-data volume (persistence
-    # lifecycle is handled by #159, not here).
-    # Without --profile staging, `down` only removes profile-less services
-    # (dev/prod) and leaves the staged container running — always pass the
-    # profile so the staged container is actually stopped.
-    $COMPOSE -f docker-compose.yml -f docker-compose.staging.yml --env-file "$ENV_FILE" --profile staging down 2>/dev/null || true
-    echo "✓ Staging stopped."
+    # Plain stop keeps the staging-data volume (persistence, #159);
+    # --purge also removes it (explicit, user-initiated data loss).
+    compose_down
+    if [ "$purge" -eq 1 ]; then
+        echo "==> Purging staging data volume '${STAGING_DATA_VOLUME}'..."
+        docker volume rm "$STAGING_DATA_VOLUME" 2>/dev/null || \
+            docker volume rm "riks-context-engine_${STAGING_DATA_VOLUME}" 2>/dev/null || true
+        echo "✓ Staging stopped and data volume purged."
+    else
+        echo "✓ Staging stopped (data volume preserved)."
+    fi
 }
 
 restart_staging() {
     stop_staging
-    start_staging
+    start_staging "$@"
 }
 
 status_staging() {
@@ -154,6 +189,53 @@ status_staging() {
     fi
     echo ""
     echo "API Health: $(curl -sf "${STAGING_API_URL}/health" 2>/dev/null || echo 'unavailable')"
+}
+
+smoke_staging() {
+    resolve_staging_api_url
+    echo "==> Smoke testing ${STAGING_API_URL}..."
+
+    # 1) Health endpoint must answer 200 (unauthenticated).
+    local health_code
+    health_code="$(curl -s -o /dev/null -w '%{http_code}' "${STAGING_API_URL}/health")"
+    if [ "$health_code" != "200" ]; then
+        echo "FAIL: /health returned ${health_code} (expected 200)." >&2
+        exit 1
+    fi
+    echo "✓ /health → 200"
+
+    # 2) Fail-closed auth (#166): a protected endpoint without an API key
+    #    must be rejected (401/403). With a key from .env.staging it must
+    #    be served (200) — proves the key actually works.
+    local protected_code
+    protected_code="$(curl -s -o /dev/null -w '%{http_code}' -H 'X-Tenant-Id: smoke-test' "${STAGING_API_URL}/api/v1/memory/export?format=json")"
+    case "$protected_code" in
+        401 | 403)
+            echo "✓ /api/v1/memory/export without key → ${protected_code} (fail-closed auth OK)"
+            ;;
+        *)
+            echo "FAIL: /api/v1/memory/export without key returned ${protected_code} (expected 401/403 — auth NOT fail-closed)." >&2
+            exit 1
+            ;;
+    esac
+
+    local api_key=""
+    if [ -f "$ENV_FILE" ]; then
+        api_key="$(sed -n 's/^STAGING_API_KEY=//p' "$ENV_FILE" 2>/dev/null | tail -n1)"
+    fi
+    if [ -n "$api_key" ]; then
+        local authed_code
+        authed_code="$(curl -s -o /dev/null -w '%{http_code}' -H "X-API-Key: ${api_key}" -H 'X-Tenant-Id: smoke-test' "${STAGING_API_URL}/api/v1/memory/export?format=json")"
+        if [ "$authed_code" != "200" ]; then
+            echo "FAIL: /api/v1/memory/export with STAGING_API_KEY returned ${authed_code} (expected 200)." >&2
+            exit 1
+        fi
+        echo "✓ /api/v1/memory/export with key → 200 (authed path OK)"
+    else
+        echo "NOTE: no STAGING_API_KEY in ${ENV_FILE}; authed path not checked."
+    fi
+
+    echo "✓ Smoke test passed."
 }
 
 logs_staging() {
@@ -194,19 +276,29 @@ show_help() {
 Usage: ./scripts/staging.sh <command>
 
 Commands:
-  start     Start staging environment (overlay: base + staging compose)
-  stop      Stop staging environment (data volume preserved)
-  restart   Restart staging environment
+  start [--rebuild]  Start staging (idempotent; --rebuild: local build,
+                     skipping the CI image pull — arm64 hosts build with
+                     the drift-guarded Dockerfile.arm64)
+  stop [--purge]     Stop staging (data volume preserved; --purge deletes
+                     the staging-data volume)
+  restart [--rebuild]  Restart staging (passes flags through)
   status    Show staging status + health
+  smoke     Smoke test: /health 200 + fail-closed auth (401 without key,
+            200 with STAGING_API_KEY)
   logs      Tail staging logs
   test      Run tests against staging
   help      Show this help
 
 Env: STAGING_API_URL is read from .env.staging (default http://localhost:8001).
+     STAGING_SHA selects the CI image tag staging-<sha> (default: git HEAD
+     short sha; fallback: floating `staging` tag with a warning).
 
 Examples:
   ./scripts/staging.sh start
+  ./scripts/staging.sh start --rebuild
+  ./scripts/staging.sh stop --purge
   ./scripts/staging.sh status
+  ./scripts/staging.sh smoke
   ./scripts/staging.sh logs
   ./scripts/staging.sh test
 EOF
@@ -215,12 +307,14 @@ EOF
 # ── Main ───────────────────────────────────────────────────────────────────────
 
 COMMAND="${1:-help}"
+shift || true
 
 case "$COMMAND" in
-    start)      start_staging ;;
-    stop)       stop_staging ;;
-    restart)    restart_staging ;;
+    start)      start_staging "$@" ;;
+    stop)       stop_staging "$@" ;;
+    restart)    restart_staging "$@" ;;
     status)     status_staging ;;
+    smoke)      smoke_staging ;;
     logs)       logs_staging ;;
     test)       test_staging ;;
     help)       show_help ;;

--- a/scripts/test-staging.sh
+++ b/scripts/test-staging.sh
@@ -15,6 +15,11 @@ ENV_FILE=".env.staging"
 ENV_EXAMPLE=".env.staging.example"
 RESULTS_DIR="test-results"
 
+# Shared helpers (#159): GHCR staging-<sha> resolution + drift-guarded
+# local-build fallback, shared with scripts/staging.sh.
+# shellcheck source=scripts/lib/staging-common.sh
+. "$SCRIPT_DIR/lib/staging-common.sh"
+
 # ── Compose resolver (plugin first, legacy fallback) ─────────────────────────
 
 resolve_compose() {
@@ -61,25 +66,12 @@ start_staging() {
     resolve_staging_api_url
     echo "==> Starting STAGING environment (API: ${STAGING_API_URL})..."
     # Overlay stack: base + staging (staging service, port 8001).
-    # Image: GHCR (host-arch) preferred, local build fallback (see
-    # scripts/staging.sh start_staging for the same logic).
+    # Image (#159): CI image `staging-<sha>` (STAGING_SHA env → git HEAD →
+    # floating tag) preferred, no `--build` on the default path: local
+    # CI image → pull → pre-existing local image → drift-guarded local
+    # build (same behavior as scripts/staging.sh start).
     if ! docker ps --format '{{.Names}}' | grep -q "^riks-context-engine-staging$"; then
-        local host_arch
-        host_arch="$(uname -m)"
-        case "$host_arch" in
-            aarch64 | arm64) host_arch="arm64" ;;
-            x86_64) host_arch="amd64" ;;
-        esac
-        local ghcr_image="ghcr.io/vopsiton/riks-context-engine:staging"
-        if ! docker pull --platform "linux/${host_arch}" "$ghcr_image" 2>/dev/null; then
-            echo "WARNING: GHCR pull failed; local build fallback."
-            if [ "$host_arch" = "arm64" ] && [ ! -f Dockerfile.arm64 ]; then
-                python3 scripts/gen_dockerfile_arm64.py > Dockerfile.arm64
-                docker build --platform linux/arm64 -f Dockerfile.arm64 -t riks-context-engine:staging .
-            else
-                $COMPOSE -f docker-compose.yml -f docker-compose.staging.yml --env-file "$ENV_FILE" build staging || true
-            fi
-        fi
+        ensure_staging_image
     fi
     compose_up
     echo "==> Waiting for staging to be healthy..."


### PR DESCRIPTION
## Ne değişti

#159 (opsiton payı): staging single-command lifecycle + CI image source + Dockerfile.arm64 senkron + persistence guards.

- `scripts/staging.sh`: `stop [--purge]`, `start [--rebuild]`, `restart` (flag passthrough), **yeni `smoke`** (/health 200 + fail-closed auth: 401 key'siz, 200 `STAGING_API_KEY` ile)
- `scripts/lib/staging-common.sh` (yeni, staging.sh + test-staging.sh ortak):
  - CI image resolution: `STAGING_SHA` env → `git rev-parse --short HEAD` → floating `staging` tag (uyarıyla) — cd.yml `deploy-staging`'in fiilen push ettiği `staging-<sha>` tag'iyle birebir aynı
  - `ensure_staging_image`: lokal CI image → `docker pull --platform` (host arch) → mevcut lokal image (uyarıyla) → drift-guarded lokal build
  - `local_build_fallback`: arm64 host → **sadece** `Dockerfile.arm64`; amd64 host → `Dockerfile` (amd64 Dockerfile'ın arm64'ta build edilmesi — exec format error'ın kök nedeni — artık mümkün değil)
  - `check_arm64_dockerfile_sync`: gen script ile regenerate + committed dosyayla diff → drift fail (cd.yml arm64-build job'ındaki guard ile aynı)
- `scripts/test-staging.sh`: default path artık `--build` değil (pull-first, aynı fallback sırası), aynı helper'ı kullanıyor
- `docker-compose.staging.yml`: `build:` bölümü **kaldırıldı** — compose artık lokal image kullanıp fail-fast (pull: missing) oluyor; sessizce amd64 Dockerfile ile rebuild yok
- `Dockerfile.arm64`: repo'ya commit edildi (önceden untracked, on-the-fly generate)

## AC Mapping + Kanıtlar

**AC1 (lifecycle):** `stop` volume'u koruyor (`✓ Staging stopped (data volume preserved)`); `stop --purge` `staging-data` volume'unu siliyor (explicit). `smoke` çalışıyor:
```
✓ /health → 200
✓ /api/v1/memory/export without key → 401 (fail-closed auth OK)
✓ /api/v1/memory/export with key → 200 (authed path OK)
```
`staging.sh status`:
```
Container: RUNNING  /  Image: riks-context-engine:staging  /  Status: Up (healthy)
API Health: {"status":"ok"}
```

**AC2 (veri korunma):** staging'e 3 episodic entry yazıldı (`ep_ac2_1/2/3`, tenant `persist-ac2`, HTTP import), `stop` → volume `riks-context-engine_staging-data` mevcut kaldı → `start` → volume'daki `/app/data/episodic.json` 3 entry'yi içeriyor (5 total: 2 eski + 3 yeni) — **volume persistence KANITLANDI**.
⚠️ **Bulunan bug (fix bu PR'ın kapsamı DIŞINDA — ayrı issue önerisi aşağıda):** `/api/v1/memory/import` + `/api/v1/memory/export` `X-Tenant-Id` header'ına rağmen **module-level singleton store'a** (`_episodic_memory`, `{data_dir}/episodic.json`) yazıyor/okuyor; tenant-scoped registry yalnızca `/api/chat` + context endpoint'lerinde kullanılıyor. Sonuç: (a) tenant A import → tenant B export aynı kayıtları görüyor (izolasyon deliği), (b) endpoint level'da "import→export roundtrip" tenant başına görünmüyor (staging'de export count 0 dönerken volume'da 3 entry duruyordu). #167 e2e testi in-process singleton'ı doğrudan kullandığı için bunu yakalamadı. **Öneri:** P1/P2 issue aç — import/export endpoint'lerini tenant-scoped registry'e bağla (chat'teki pattern).

**AC3 (CI image source):** resolution zinciri + pull-first implement edildi (kod + yardımcı). Kanıt sınırlaması: GHCR'a `staging-<sha>` tag'li image henüz push EDİLMEDİ (cd.yml deploy-staging 4 merge'dir kırık — aşağıda [BİLGİ]) ve bu PR'ın kendi sha'sı da henüz CI tarafından build edilmedi → `docker ps`'de `staging-<sha>` tag'li canlı container kanıtı ŞİMDİLİK verilemiyor; Rik'in CD fix'i + bu PR'ın merge'i sonrası ilk staging deploy'da doğrulanacak. Kod yolu: `ensure_staging_image` → `staging-<sha>` (STAGING_SHA/HEAD) → pull → retag → compose.

**AC4 (CD fix):** Rik'te — bu PR'a dahil değil, cd.yml'a dokunulmadı. [BİLGİ] aşağıda.

**AC5 (exec format error):** Kök neden doğrulandı: **digest'ler DOĞRU** (Docker Hub'dan 2026-08-21 doğrulandı: amd64 `sha256:876416ec...`, arm64 v8 `sha256:0568e61118...` — iki Dockerfile zaten doğru pin'li). Hata, arm64 host'ta checked-in **amd64 Dockerfile'ın build edilmesi**den geliyordu (eski fallback kol + compose `build:`'i). Kalıcı çözüm: compose `build:` kaldırıldı + fallback arch-düz doğru Dockerfile seçiyor + drift guard. Kanıt sınırlaması: bu makinede arm64'ta `docker build` denemesi yapılmadı (çalışan staging container'ını rebuild riski + base image pull süresi); guard'ın kendisi çalışır durumda (drift varsa build'i fail ettirir — `check_arm64_dockerfile_sync` bu PR'da çalıştırıldı, clean).

## Rik'e [BİLGİ] — cd.yml deploy-staging (AC4)

Hata: `denied: installation not allowed to Write organization package` — GHA'nın `GITHUB_TOKEN`'u org-level GHCR package'ına push yapamıyor (org ayarında app/installation'ın org package yazma izni yok). İki seçenek:

1. **(Tavsiye, en az risk)** Org'da `vopsiton` user'ına GHCR package collaborator (write) ver → fine-grained PAT oluştur (`packages: write` scope, repo `vopsiton/riks-context-engine` + org package) → `secrets.PAT_GHCR` ekle → `cd.yml` deploy-staging login adımında `password: ${{ secrets.PAT_GHCR }}` (GITHUB_TOKEN yerine).
2. Org settings → **Advanced Security / Code Scanning → Package registry access** (ya da org → Settings → Packages → access) → GitHub Apps'e write izni ver (org admin panelinden). Bu da admin yetkisi gerektiriyor.

Not: `ci.yml`'deki `Docker Build & Scan` + `Docker Build arm64 (no push)` job'ları push YAPMADIĞI için çalışıyor; tek kırık nokta push'lu deploy-staging.

## Test

- `uv run pytest tests/` → **687 passed**, 23 skipped, 3 xfailed, 3 xpassed
- `uv run ruff check scripts/` ✅ · `uv run ruff format --check scripts/` ✅
- `bash -n` (staging.sh, test-staging.sh, staging-common.sh) ✅
- Staging smoke (yukarıda) ✅