### PR TITLE
fix: tenant-scope memory import/export endpoints [P1] (#184)

### DIFF
--- a/src/riks_context_engine/api/server.py
+++ b/src/riks_context_engine/api/server.py
@@ -862,16 +862,25 @@ def chat(req: ChatRequest, request: Request) -> ChatResponse:
 
 
 @app.get("/", include_in_schema=False)
-def root() -> FileResponse | MemoryExportResponse:
+async def root(request: Request) -> Response:
     """UI index, or a memory export when the UI is not deployed.
 
     Excluded from the OpenAPI spec (#123): the canonical export endpoint is
     GET /api/v1/memory/export; this alias preserves legacy behavior.
+    Tenant-scoped via X-Tenant-Id (#184): exports the caller's own memory.
+    Non-tenant callers (e.g. unauthenticated health-check UI loads) get
+    the UI; only authenticated tenant calls take the export branch.
+
+    Returns a Response object directly (no pydantic serialization) because
+    it mixes JSON (MemoryExportResponse) and file (FileResponse) payloads.
     """
-    if _episodic_memory is not None and not os.path.exists(
-        os.environ.get("UI_PATH", "ui/index.html")
+    if (
+        _episodic_memory is not None
+        and not os.path.exists(os.environ.get("UI_PATH", "ui/index.html"))
+        and getattr(request.state, "tenant_id", None) is not None
     ):
-        return _export_memory(None, "json", None, None, None)
+        export = _export_memory(request, None, "json", None, None, None, request.state.tenant_id)
+        return JSONResponse(export.model_dump())
     return FileResponse(os.environ.get("UI_PATH", "ui/index.html"))
 
 
@@ -965,19 +974,26 @@ class MemoryImportResponse(BaseModel):
 
 
 def _export_memory(
+    request: Request,
     types: str | None,
     format: Literal["json", "yaml"],
     date_from: datetime | None,
     date_to: datetime | None,
     tags: list[str] | None,
+    tenant_id: str,
 ) -> MemoryExportResponse:
-    """Shared export logic (canonical endpoint + GET / alias)."""
+    """Shared export logic (canonical endpoint + GET / alias).
+
+    Tenant-scoped (#184): reads the caller's per-tenant memory stores from
+    the tenant-scoped registry (same pattern as /api/chat, #158), NOT the
+    module-level singletons.
+    """
     include_types = [t.strip() for t in types.split(",")] if types else None
 
     manifest = export_memory(
-        episodic_memory=_episodic_memory,
-        semantic_memory=_semantic_memory,
-        procedural_memory=_procedural_memory,
+        episodic_memory=_tenant_memory_registry.get_episodic(tenant_id),
+        semantic_memory=_tenant_memory_registry.get_semantic(tenant_id),
+        procedural_memory=_tenant_memory_registry.get_procedural(tenant_id),
         include_types=include_types,
         date_from=date_from,
         date_to=date_to,
@@ -1001,6 +1017,7 @@ def _export_memory(
 
 @app.get("/api/v1/memory/export", response_model=MemoryExportResponse, tags=["memory"])
 def export_memory_api(
+    request: Request,
     types: Annotated[
         str | None,
         Query(description="Comma-separated types: episodic,semantic,procedural"),
@@ -1020,12 +1037,19 @@ def export_memory_api(
     if format is None:
         format = "json"
     tag_list = [t.strip() for t in tags.split(",")] if tags else None
-    return _export_memory(types, format, date_from, date_to, tag_list)
+    tenant_id: str = request.state.tenant_id  # set by TenantAuthMiddleware
+    return _export_memory(request, types, format, date_from, date_to, tag_list, tenant_id)
 
 
 @app.post("/api/v1/memory/import", response_model=MemoryImportResponse, tags=["memory"])
-def import_memory_api(req: MemoryImportRequest) -> MemoryImportResponse:
-    """Import memory tiers from a JSON or YAML manifest (tenant-scoped)."""
+def import_memory_api(req: MemoryImportRequest, request: Request) -> MemoryImportResponse:
+    """Import memory tiers from a JSON or YAML manifest (tenant-scoped, #184).
+
+    Writes into the caller's per-tenant stores from the tenant-scoped
+    registry (same pattern as /api/chat, #158), so one tenant's import can
+    never leak into another tenant's memory.
+    """
+    tenant_id: str = request.state.tenant_id  # set by TenantAuthMiddleware
     try:
         manifest = parse_manifest(req.content, req.format)
     except ValueError as e:
@@ -1033,15 +1057,14 @@ def import_memory_api(req: MemoryImportRequest) -> MemoryImportResponse:
 
     imported = import_to_memory(
         manifest,
-        episodic_memory=_episodic_memory,
-        semantic_memory=_semantic_memory,
-        procedural_memory=_procedural_memory,
+        episodic_memory=_tenant_memory_registry.get_episodic(tenant_id),
+        semantic_memory=_tenant_memory_registry.get_semantic(tenant_id),
+        procedural_memory=_tenant_memory_registry.get_procedural(tenant_id),
         merge=req.merge,
     )
     # Critical-operation audit (memory.add/import) — in-process hook (#110).
     try:
-        _audit_tenant = os.environ.get("RIKS_TENANT_ID", "").strip() or "unauthenticated"
-        get_audit_log(_audit_tenant).record_operation(
+        get_audit_log(tenant_id).record_operation(
             CRITICAL_MEMORY_IMPORT,
             endpoint="/api/v1/memory/import",
             method="POST",

--- a/tests/test_api/test_memory_roundtrip_e2e.py
+++ b/tests/test_api/test_memory_roundtrip_e2e.py
@@ -15,11 +15,12 @@ surface (never a real staging endpoint):
    sets on all deterministic fields (timestamp-derived ids, metadata
    timestamps and access counters are excluded by design).
 
-NOTE on stores: the export/import endpoints read the module-level
-singleton memory stores (set by the app lifespan), while /api/chat
-wires tenant-scoped stores (#158). The roundtrip is therefore exercised
-on the stores the endpoints actually touch — seeded via the same
-add/store APIs the import path uses.
+NOTE on stores (#184): the export/import endpoints are tenant-scoped —
+they read/write the caller's per-tenant stores from the
+``TenantMemoryRegistry`` (same pattern as /api/chat, #158). The roundtrip
+is therefore exercised end-to-end over HTTP: tenant A seeds by importing
+its own manifest and all assertions run through tenant-scoped exports,
+so tenant B's calls provably never see or mutate tenant A's data.
 """
 
 from __future__ import annotations
@@ -46,14 +47,85 @@ DETERMINISTIC_FIELDS: dict[str, list[str]] = {
     "procedural": ["name", "description", "steps", "tags", "type"],
 }
 
+_SEED_MANIFEST: dict[str, Any] = {
+    "metadata": {
+        "schema_version": memory_export.SCHEMA_VERSION,
+        "exported_at": "2026-08-20T00:00:00+00:00",
+        "tool": "riks-context-engine",
+        "export_id": "rt-seed",
+    },
+    "episodic": [
+        {
+            "id": "rt_ep1",
+            "timestamp": "2026-08-20T10:00:00+00:00",
+            "content": "deployed the k8s manifests on the staging cluster",
+            "importance": 0.9,
+            "embedding": [0.1, 0.2, 0.3],
+            "tags": ["ops", "deploy"],
+            "type": "episodic",
+        },
+        {
+            "id": "rt_ep2",
+            "timestamp": "2026-08-20T11:00:00+00:00",
+            "content": "fixed the RBAC fail-closed auth bug",
+            "importance": 0.7,
+            "embedding": None,
+            "tags": ["security"],
+            "type": "episodic",
+        },
+    ],
+    "semantic": [
+        {
+            "id": "rt_sem1",
+            "subject": "user",
+            "predicate": "name",
+            "object": "Vahit",
+            "confidence": 1.0,
+            "created_at": "2026-08-20T10:00:00+00:00",
+            "last_accessed": "2026-08-20T10:00:00+00:00",
+            "access_count": 0,
+            "embedding": [0.5, 0.5, 0.5],
+            "type": "semantic",
+        },
+        {
+            "id": "rt_sem2",
+            "subject": "service",
+            "predicate": "stack",
+            "object": "fastapi + sqlite + redis",
+            "confidence": 0.8,
+            "created_at": "2026-08-20T11:00:00+00:00",
+            "last_accessed": "2026-08-20T11:00:00+00:00",
+            "access_count": 0,
+            "embedding": None,
+            "type": "semantic",
+        },
+    ],
+    "procedural": [
+        {
+            "id": "rt_proc1",
+            "name": "daily_backup",
+            "description": "Nightly memory snapshot routine",
+            "steps": ["snapshot memory", "verify checksum", "archive"],
+            "created_at": "2026-08-20T09:00:00+00:00",
+            "last_used": "2026-08-20T09:00:00+00:00",
+            "use_count": 0,
+            "success_rate": 1.0,
+            "tags": ["ops", "backup"],
+            "type": "procedural",
+        },
+    ],
+}
+
+_SEED_COUNTS = {"episodic": 2, "semantic": 2, "procedural": 1}
+
 
 @pytest.fixture(autouse=True)
-def _fresh_singleton_stores(tmp_path, monkeypatch):
-    """Point the app's singleton memory stores at a per-test temp dir.
+def _fresh_tenant_stores(tmp_path, monkeypatch):
+    """Isolate the tenant-scoped registry in a per-test temp dir.
 
-    Patches the lifespan (which creates the singletons the export/import
-    endpoints read) and clears the tenant-scoped memory registry so no
-    state leaks between tests.
+    The export/import endpoints are tenant-scoped (#184): they read/write
+    the caller's stores from ``_tenant_memory_registry``. Each test gets
+    a fresh registry data dir so no state leaks between tests.
     """
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     _tenant_memory_registry._semantic.clear()
@@ -87,42 +159,21 @@ def client():
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 
-def _seed_stores(server: Any) -> None:
-    """Populate the singleton stores the endpoints read (API-level seeding).
+def _seed_tenant(client: TestClient, headers: dict[str, str]) -> dict[str, Any]:
+    """Seed a tenant's scoped store via the HTTP import path.
 
-    Same add/store calls the import path makes, so the roundtrip starts
-    from a known, non-empty state.
+    Tenant-scoped import (#184): seeding tenant A via its own header only
+    writes into tenant A's registry store, so every later roundtrip
+    assertion exercises the same stores the endpoints use.
     """
-    server._episodic_memory.add(
-        content="deployed the k8s manifests on the staging cluster",
-        importance=0.9,
-        tags=["ops", "deploy"],
-        embedding=[0.1, 0.2, 0.3],
+    r = client.post(
+        "/api/v1/memory/import",
+        json={"content": json.dumps(_SEED_MANIFEST), "format": "json", "merge": True},
+        headers=headers,
     )
-    server._episodic_memory.add(
-        content="fixed the RBAC fail-closed auth bug",
-        importance=0.7,
-        tags=["security"],
-    )
-    server._semantic_memory.add(
-        subject="user",
-        predicate="name",
-        object="Vahit",
-        confidence=1.0,
-        embedding=[0.5, 0.5, 0.5],
-    )
-    server._semantic_memory.add(
-        subject="service",
-        predicate="stack",
-        object="fastapi + sqlite + redis",
-        confidence=0.8,
-    )
-    server._procedural_memory.store(
-        name="daily_backup",
-        description="Nightly memory snapshot routine",
-        steps=["snapshot memory", "verify checksum", "archive"],
-        tags=["ops", "backup"],
-    )
+    assert r.status_code == 200, f"seed import failed: {r.text}"
+    assert r.json()["imported"] == _SEED_COUNTS
+    return _SEED_MANIFEST
 
 
 def _export(client: TestClient, headers: dict[str, str]) -> dict[str, Any]:
@@ -158,7 +209,7 @@ def _record_content_set(records: list[dict[str, Any]], fields: list[str]) -> set
 
 class TestRoundtrip:
     def test_export_response_schema(self, client: TestClient):
-        _seed_stores(server_module)
+        _seed_tenant(client, TENANT_A)
         data = _export(client, TENANT_A)
 
         assert data["schema_version"] == memory_export.SCHEMA_VERSION
@@ -174,18 +225,14 @@ class TestRoundtrip:
             assert data["counts"][tier] == len(m[tier])
 
     def test_export_counts_match_seeded_state(self, client: TestClient):
-        _seed_stores(server_module)
+        _seed_tenant(client, TENANT_A)
         data = _export(client, TENANT_A)
         m = _manifest(data)
-        assert data["counts"] == {
-            "episodic": 2,
-            "semantic": 2,
-            "procedural": 1,
-        }
+        assert data["counts"] == _SEED_COUNTS
         assert all(rec["type"] == tier for tier in TIER_KEYS for rec in m[tier])
 
     def test_export_selective_types_filter(self, client: TestClient):
-        _seed_stores(server_module)
+        _seed_tenant(client, TENANT_A)
         r = client.get(
             "/api/v1/memory/export",
             params={"format": "json", "types": "semantic"},
@@ -200,7 +247,7 @@ class TestRoundtrip:
     def test_import_after_export_roundtrip_no_data_loss(self, client: TestClient):
         """Re-import an export into the same tenant: nothing lost, nothing
         duplicated (merge=True skips existing ids)."""
-        _seed_stores(server_module)
+        _seed_tenant(client, TENANT_A)
         data = _export(client, TENANT_A)
         m = _manifest(data)
 
@@ -208,21 +255,37 @@ class TestRoundtrip:
         assert body["schema_version"] == memory_export.SCHEMA_VERSION
         assert body["imported"] == dict.fromkeys(TIER_KEYS, 0)
 
-        # Every exported record is still reachable with the same content.
+        # Every exported record is still reachable in the tenant's scoped
+        # store, verified via a fresh export (full HTTP roundtrip).
+        after_manifest = _manifest(_export(client, TENANT_A))
+        for tier in TIER_KEYS:
+            assert _record_content_set(after_manifest[tier], DETERMINISTIC_FIELDS[tier]) == (
+                _record_content_set(m[tier], DETERMINISTIC_FIELDS[tier])
+            ), f"{tier} records lost after roundtrip"
+
+        # Store-level check on the tenant's registry store (not the
+        # module-level singletons — those are no longer the endpoint's
+        # data path since #184).
         for rec in m["episodic"]:
-            entry = server_module._episodic_memory.entries[rec["id"]]
+            entry = _tenant_memory_registry.get_episodic(TENANT_A["X-Tenant-Id"]).entries[rec["id"]]
             assert entry.content == rec["content"]
             assert entry.importance == rec["importance"]
             assert (entry.tags or []) == (rec["tags"] or [])
             assert entry.embedding == rec["embedding"]
         for rec in m["semantic"]:
-            matched = [row for row in server_module._semantic_memory.query() if row.id == rec["id"]]
+            matched = [
+                row
+                for row in _tenant_memory_registry.get_semantic(TENANT_A["X-Tenant-Id"]).query()
+                if row.id == rec["id"]
+            ]
             assert matched, f"semantic record {rec['id']} lost after roundtrip"
             assert matched[0].subject == rec["subject"]
             assert matched[0].predicate == rec["predicate"]
             assert matched[0].object == rec["object"]
         for rec in m["procedural"]:
-            proc = server_module._procedural_memory.procedures[rec["id"]]
+            proc = _tenant_memory_registry.get_procedural(TENANT_A["X-Tenant-Id"]).procedures[
+                rec["id"]
+            ]
             assert proc.name == rec["name"]
             assert list(proc.steps) == list(rec["steps"])
 
@@ -231,20 +294,23 @@ class TestRoundtrip:
         assert after["counts"] == data["counts"]
 
     def test_reimport_after_wipe_restores_all_records(self, client: TestClient):
-        """Export → wipe the stores → import again: every record restored."""
-        _seed_stores(server_module)
+        """Export → wipe the tenant's store → import again: every record
+        restored (merge=False wipes the caller's scoped store only)."""
+        _seed_tenant(client, TENANT_A)
         data = _export(client, TENANT_A)
         m = _manifest(data)
         expected = {tier: len(m[tier]) for tier in TIER_KEYS}
         assert sum(expected.values()) == 5
 
-        # Wipe (simulates a fresh/lost instance).
-        for epi_id in list(server_module._episodic_memory.entries):
-            server_module._episodic_memory.delete(epi_id)
-        for row in server_module._semantic_memory.query():
-            server_module._semantic_memory.delete(row.id)
-        for proc_id in list(server_module._procedural_memory.procedures):
-            server_module._procedural_memory.delete(proc_id)
+        tenant_a = TENANT_A["X-Tenant-Id"]
+        # Wipe (simulates a fresh/lost instance) — via the tenant's scoped
+        # registry stores, the same stores the endpoints read.
+        for epi_id in list(_tenant_memory_registry.get_episodic(tenant_a).entries):
+            _tenant_memory_registry.get_episodic(tenant_a).delete(epi_id)
+        for row in _tenant_memory_registry.get_semantic(tenant_a).query():
+            _tenant_memory_registry.get_semantic(tenant_a).delete(row.id)
+        for proc_id in list(_tenant_memory_registry.get_procedural(tenant_a).procedures):
+            _tenant_memory_registry.get_procedural(tenant_a).delete(proc_id)
         assert _export(client, TENANT_A)["counts"] == dict.fromkeys(TIER_KEYS, 0)
 
         r = client.post(
@@ -265,7 +331,7 @@ class TestRoundtrip:
 
     def test_yaml_roundtrip(self, client: TestClient):
         """Same roundtrip contract in YAML format."""
-        _seed_stores(server_module)
+        _seed_tenant(client, TENANT_A)
         r = client.get("/api/v1/memory/export", params={"format": "yaml"}, headers=TENANT_A)
         assert r.status_code == 200
         r2 = client.post(
@@ -279,6 +345,7 @@ class TestRoundtrip:
         assert _export(client, TENANT_A)["counts"]["episodic"] == 2
 
     def test_import_rejects_bad_schema_400(self, client: TestClient):
+        _seed_tenant(client, TENANT_A)
         good = _manifest(_export(client, TENANT_A))
         good["metadata"]["schema_version"] = "9.9"  # incompatible major
         r = client.post(
@@ -295,10 +362,12 @@ class TestRoundtrip:
 class TestTenantIsolation:
     def test_import_by_b_does_not_touch_a(self, client: TestClient):
         """A's data, imported under B's credentials, must not appear in or
-        alter A's store."""
-        _seed_stores(server_module)
+        alter A's store (and must land in B's store)."""
+        _seed_tenant(client, TENANT_A)
         a_before = _export(client, TENANT_A)
         a_counts_before = a_before["counts"]
+        # B starts empty: scoped isolation, not just non-mutation.
+        assert _export(client, TENANT_B)["counts"] == dict.fromkeys(TIER_KEYS, 0)
 
         # B imports A's exported manifest under B's tenant.
         r = client.post(
@@ -307,6 +376,7 @@ class TestTenantIsolation:
             headers=TENANT_B,
         )
         assert r.status_code == 200, r.text
+        assert r.json()["imported"] == a_counts_before
 
         a_after = _export(client, TENANT_A)
         assert a_after["counts"] == a_counts_before, (
@@ -319,10 +389,13 @@ class TestTenantIsolation:
             before_set = _record_content_set(m_before[tier], DETERMINISTIC_FIELDS[tier])
             after_set = _record_content_set(m_after[tier], DETERMINISTIC_FIELDS[tier])
             assert before_set == after_set
+        # B's store received the import (proves writes went to the caller's
+        # scoped store, not a shared one).
+        assert _export(client, TENANT_B)["counts"] == a_counts_before
 
     def test_merge_false_by_b_never_wipes_a(self, client: TestClient):
         """merge=False import under B must not wipe A's seeded data."""
-        _seed_stores(server_module)
+        _seed_tenant(client, TENANT_A)
         a_before = _export(client, TENANT_A)
         r = client.post(
             "/api/v1/memory/import",
@@ -336,14 +409,15 @@ class TestTenantIsolation:
             "tenant A's store was wiped/changed by tenant B's merge=False import"
         )
 
-    def test_export_reflects_only_caller_tenant_state(self, client: TestClient):
-        """Export is deterministic per store state: exporting from any
-        tenant header returns the same (tenant-scoped) manifest content."""
-        _seed_stores(server_module)
+    def test_export_scoped_to_caller_tenant_only(self, client: TestClient):
+        """Export is tenant-scoped: A's seeded data is visible to A only,
+        and B's export is empty (AC2: cross-tenant export leak closed)."""
+        _seed_tenant(client, TENANT_A)
         m_a = _manifest(_export(client, TENANT_A))
         m_b = _manifest(_export(client, TENANT_B))
         for tier in TIER_KEYS:
-            assert [rec["id"] for rec in m_a[tier]] == [rec["id"] for rec in m_b[tier]]
+            assert len(m_a[tier]) == _SEED_COUNTS[tier]
+            assert m_b[tier] == [], f"tenant B exported tenant A's {tier} data"
 
 
 # ─── 3. Format stability: two consecutive exports agree ───────────────────────
@@ -351,7 +425,7 @@ class TestTenantIsolation:
 
 class TestFormatStability:
     def test_consecutive_exports_same_schema(self, client: TestClient):
-        _seed_stores(server_module)
+        _seed_tenant(client, TENANT_A)
         e1 = _export(client, TENANT_A)
         e2 = _export(client, TENANT_A)
 
@@ -366,7 +440,7 @@ class TestFormatStability:
 
     def test_consecutive_exports_deterministic_fields_equal(self, client: TestClient):
         """Same deterministic content in both exports (id/timestamp excluded)."""
-        _seed_stores(server_module)
+        _seed_tenant(client, TENANT_A)
         m1 = _manifest(_export(client, TENANT_A))
         m2 = _manifest(_export(client, TENANT_A))
         for tier in TIER_KEYS:
@@ -376,7 +450,7 @@ class TestFormatStability:
 
     def test_export_stable_across_tiers(self, client: TestClient):
         """Per-tier key stability: every record carries its canonical id/type."""
-        _seed_stores(server_module)
+        _seed_tenant(client, TENANT_A)
         m = _manifest(_export(client, TENANT_A))
         for tier in TIER_KEYS:
             for rec in m[tier]:

--- a/tests/test_api/test_memory_tenant_scoping_e2e.py
+++ b/tests/test_api/test_memory_tenant_scoping_e2e.py
@@ -1,0 +1,400 @@
+"""E2E tenant-scoping test for memory import/export (#184) — P1, CI must pass.
+
+Closes the isolation hole found in staging (#183): before the fix,
+``POST /api/v1/memory/import`` and ``GET /api/v1/memory/export`` (plus the
+``GET /`` alias) read/wrote the module-level **singleton** memory stores
+instead of the caller's tenant-scoped stores, so tenant A's import was
+visible in tenant B's export.
+
+After the fix both endpoints (and the alias) resolve the caller's stores
+from the ``TenantMemoryRegistry`` — the same pattern /api/chat uses (#158):
+each tenant gets its own EpisodicMemory/SemanticMemory/ProceduralMemory
+backed by tenant-scoped file paths.
+
+Covers the acceptance criteria against the in-app TestClient surface
+(never a real staging endpoint):
+
+- AC2: tenant A import (3 episodic) → tenant B export → 0 (isolation).
+- AC3: tenant A import → tenant A export → the same 3 records (roundtrip).
+- Import idempotency: merge=true re-import imports 0 (no duplicates).
+- Semantic + procedural tiers are tenant-scoped too (≥1 test per tier).
+- Request without a tenant header on a protected endpoint → 401
+  (fail-closed, #166 behavior must stay intact).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import riks_context_engine.api.server as server_module
+from riks_context_engine.api.server import _tenant_memory_registry, app
+from riks_context_engine.memory import export as memory_export
+
+TENANT_A = {"X-Tenant-Id": "t184-tenant-a", "X-API-Key": "test-api-key"}
+TENANT_B = {"X-Tenant-Id": "t184-tenant-b", "X-API-Key": "test-api-key"}
+API_KEY_ONLY = {"X-API-Key": "test-api-key"}  # no X-Tenant-Id
+BASE_HEADERS = {"X-Tenant-Id": "test-tenant"}  # client default (base) tenant
+
+EPISODIC_IDS = ("t184_ep1", "t184_ep2", "t184_ep3")
+SEMANTIC_IDS = ("t184_sem1", "t184_sem2")
+PROCEDURAL_IDS = ("t184_proc1",)
+
+
+def _manifest() -> dict[str, Any]:
+    """Manifest with stable explicit ids across all three tiers."""
+    return {
+        "metadata": {
+            "schema_version": memory_export.SCHEMA_VERSION,
+            "exported_at": "2026-08-21T00:00:00+00:00",
+            "tool": "riks-context-engine",
+            "export_id": "t184-fixed",
+        },
+        "episodic": [
+            {
+                "id": EPISODIC_IDS[0],
+                "timestamp": "2026-08-20T10:00:00+00:00",
+                "content": "shipped the staging tenant-scoping fix",
+                "importance": 0.9,
+                "embedding": None,
+                "tags": ["ops"],
+                "type": "episodic",
+            },
+            {
+                "id": EPISODIC_IDS[1],
+                "timestamp": "2026-08-20T11:00:00+00:00",
+                "content": "verified cross-tenant export isolation",
+                "importance": 0.8,
+                "embedding": None,
+                "tags": ["security"],
+                "type": "episodic",
+            },
+            {
+                "id": EPISODIC_IDS[2],
+                "timestamp": "2026-08-20T12:00:00+00:00",
+                "content": "rotated the import pipeline credentials",
+                "importance": 0.6,
+                "embedding": None,
+                "tags": ["security", "ops"],
+                "type": "episodic",
+            },
+        ],
+        "semantic": [
+            {
+                "id": SEMANTIC_IDS[0],
+                "subject": "service",
+                "predicate": "stack",
+                "object": "fastapi + sqlite",
+                "confidence": 0.9,
+                "created_at": "2026-08-20T10:00:00+00:00",
+                "last_accessed": "2026-08-20T10:00:00+00:00",
+                "access_count": 0,
+                "embedding": None,
+                "type": "semantic",
+            },
+            {
+                "id": SEMANTIC_IDS[1],
+                "subject": "user",
+                "predicate": "role",
+                "object": "opsiton-lead",
+                "confidence": 1.0,
+                "created_at": "2026-08-20T11:00:00+00:00",
+                "last_accessed": "2026-08-20T11:00:00+00:00",
+                "access_count": 0,
+                "embedding": None,
+                "type": "semantic",
+            },
+        ],
+        "procedural": [
+            {
+                "id": PROCEDURAL_IDS[0],
+                "name": "tenant_scoping_check",
+                "description": "Verify import/export isolation per tenant",
+                "steps": ["import as A", "export as B", "assert zero"],
+                "created_at": "2026-08-20T09:00:00+00:00",
+                "last_used": "2026-08-20T09:00:00+00:00",
+                "use_count": 0,
+                "success_rate": 1.0,
+                "tags": ["security"],
+                "type": "procedural",
+            },
+        ],
+    }
+
+
+def _expected_counts() -> dict[str, int]:
+    return {"episodic": 3, "semantic": 2, "procedural": 1}
+
+
+@pytest.fixture(autouse=True)
+def _fresh_tenant_stores(tmp_path, monkeypatch):
+    """Isolate the tenant-scoped registry in a per-test temp dir."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    _tenant_memory_registry._semantic.clear()
+    _tenant_memory_registry._episodic.clear()
+    _tenant_memory_registry._procedural.clear()
+    _tenant_memory_registry._data_dir = str(tmp_path)
+
+    async def _fresh_lifespan(_app: Any):
+        yield
+
+    monkeypatch.setattr(server_module, "lifespan", _fresh_lifespan)
+    yield
+    _tenant_memory_registry._semantic.clear()
+    _tenant_memory_registry._episodic.clear()
+    _tenant_memory_registry._procedural.clear()
+
+
+@pytest.fixture
+def client():
+    original_key = server_module.API_KEY
+    server_module.API_KEY = "test-api-key"
+    try:
+        with TestClient(app, headers=TENANT_A) as c:
+            yield c
+    finally:
+        server_module.API_KEY = original_key
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _import(
+    client: TestClient, headers: dict[str, str], manifest: dict[str, Any]
+) -> dict[str, Any]:
+    # Explicit headers replace the client defaults; always merge BASE_HEADERS.
+    r = client.post(
+        "/api/v1/memory/import",
+        json={"content": json.dumps(manifest), "format": "json", "merge": True},
+        headers={**BASE_HEADERS, **headers},
+    )
+    assert r.status_code == 200, f"import failed: {r.text}"
+    return r.json()
+
+
+def _export_body(client: TestClient, headers: dict[str, str]) -> dict[str, Any]:
+    """Tenant-scoped export. Explicit headers REPLACE the client defaults
+    (TestClient does not merge request headers with the client's base
+    headers), so the base tenant is always passed explicitly."""
+    r = client.get(
+        "/api/v1/memory/export",
+        params={"format": "json"},
+        headers={**BASE_HEADERS, **headers},
+    )
+    assert r.status_code == 200, f"export failed: {r.text}"
+    return r.json()
+
+
+def _export_ids(body: dict[str, Any], tier: str) -> set[str]:
+    return {rec["id"] for rec in json.loads(body["data"])[tier]}
+
+
+# ─── AC2: cross-tenant isolation ──────────────────────────────────────────────
+
+
+class TestCrossTenantIsolation:
+    def test_a_import_then_b_export_is_empty(self, client: TestClient) -> None:
+        """AC2: tenant A imports 3 episodic → tenant B export sees 0."""
+        body = _import(client, TENANT_A, _manifest())
+        assert body["imported"] == _expected_counts()
+
+        b_export = _export_body(client, TENANT_B)
+        assert b_export["counts"] == {"episodic": 0, "semantic": 0, "procedural": 0}
+        m = json.loads(b_export["data"])
+        assert m["episodic"] == [] and m["semantic"] == [] and m["procedural"] == []
+
+        # A still sees its own 3 episodic records.
+        a_export = _export_body(client, TENANT_A)
+        assert a_export["counts"] == _expected_counts()
+        assert _export_ids(a_export, "episodic") == set(EPISODIC_IDS)
+
+    def test_a_export_then_b_import_leaves_a_untouched(self, client: TestClient) -> None:
+        """A's exported manifest, imported by B, must not alter A's store."""
+        _import(client, TENANT_A, _manifest())
+        a_export = _export_body(client, TENANT_A)
+        assert a_export["counts"] == _expected_counts()
+        client.post(
+            "/api/v1/memory/import",
+            json={"content": a_export["data"], "format": "json", "merge": True},
+            headers={**BASE_HEADERS, **TENANT_B},
+        )
+
+        a_after = _export_body(client, TENANT_A)
+        assert a_after["counts"] == _expected_counts()
+        assert _export_ids(a_after, "episodic") == set(EPISODIC_IDS)
+
+    def test_semantic_tier_isolated(self, client: TestClient) -> None:
+        """Semantic tier is tenant-scoped: B sees 0, A sees its own 2."""
+        _import(client, TENANT_A, _manifest())
+
+        b_body = _export_body(client, TENANT_B)
+        assert json.loads(b_body["data"])["semantic"] == []
+        assert b_body["counts"]["semantic"] == 0
+        assert _export_ids(_export_body(client, TENANT_A), "semantic") == set(SEMANTIC_IDS)
+
+    def test_procedural_tier_isolated(self, client: TestClient) -> None:
+        """Procedural tier is tenant-scoped: B sees 0, A sees its own 1."""
+        _import(client, TENANT_A, _manifest())
+
+        b_body = _export_body(client, TENANT_B)
+        assert json.loads(b_body["data"])["procedural"] == []
+        assert b_body["counts"]["procedural"] == 0
+        assert _export_ids(_export_body(client, TENANT_A), "procedural") == set(PROCEDURAL_IDS)
+
+
+# ─── AC3: same-tenant roundtrip ───────────────────────────────────────────────
+
+
+class TestSameTenantRoundtrip:
+    def test_a_import_then_a_export_roundtrip(self, client: TestClient) -> None:
+        """AC3: A imports 3 episodic → A export returns the same 3."""
+        _import(client, TENANT_A, _manifest())
+
+        body = _export_body(client, TENANT_A)
+        assert body["counts"] == _expected_counts()
+        m = json.loads(body["data"])
+        assert _export_ids(body, "episodic") == set(EPISODIC_IDS)
+        # Content-level roundtrip: the imported content is intact.
+        by_id = {rec["id"]: rec for rec in m["episodic"]}
+        assert by_id[EPISODIC_IDS[0]]["content"] == "shipped the staging tenant-scoping fix"
+        assert by_id[EPISODIC_IDS[1]]["importance"] == 0.8
+        assert by_id[EPISODIC_IDS[2]]["tags"] == ["security", "ops"]
+        assert _export_ids(body, "semantic") == set(SEMANTIC_IDS)
+        assert _export_ids(body, "procedural") == set(PROCEDURAL_IDS)
+
+
+# ─── Import idempotency ───────────────────────────────────────────────────────
+
+
+class TestImportIdempotency:
+    def test_merge_true_reimport_imports_zero(self, client: TestClient) -> None:
+        """merge=true: a second import of the same manifest is a no-op
+        (duplicate ids are skipped), counts stay constant."""
+        manifest = _manifest()
+        first = _import(client, TENANT_A, manifest)
+        assert first["imported"] == _expected_counts()
+
+        second = _import(client, TENANT_A, manifest)
+        assert second["imported"] == {"episodic": 0, "semantic": 0, "procedural": 0}, (
+            f"re-import must not duplicate, got: {second['imported']}"
+        )
+
+        body = _export_body(client, TENANT_A)
+        assert body["counts"] == _expected_counts()
+        assert len(json.loads(body["data"])["episodic"]) == 3
+
+    def test_reimport_under_different_tenant_is_scoped(self, client: TestClient) -> None:
+        """Re-importing under tenant B writes only to B's store."""
+        manifest = _manifest()
+        _import(client, TENANT_A, manifest)
+        b_first = _import(client, TENANT_B, manifest)
+        assert b_first["imported"] == _expected_counts()
+        # A is untouched; B has its own copy.
+        assert _export_body(client, TENANT_A)["counts"] == _expected_counts()
+        assert _export_body(client, TENANT_B)["counts"] == _expected_counts()
+
+
+# ─── Fail-closed auth (must not regress #166) ─────────────────────────────────
+
+
+class TestFailClosed:
+    # NOTE: the shared ``client`` fixture is created with base headers
+    # (X-Tenant-Id: test-tenant). httpx does NOT let per-request headers
+    # *remove* a client-level header — it re-sends the default tenant on
+    # every request. So a genuinely tenant-less request needs a fresh
+    # TestClient without base headers (that is what the real network does).
+
+    def test_missing_tenant_header_export_401(self, client: TestClient) -> None:
+        with TestClient(app) as fresh:
+            r = fresh.get(
+                "/api/v1/memory/export",
+                params={"format": "json"},
+                headers={"X-API-Key": "test-api-key"},
+            )
+        assert r.status_code == 401, f"expected 401, got {r.status_code}: {r.text}"
+
+    def test_missing_tenant_header_import_401(self, client: TestClient) -> None:
+        with TestClient(app) as fresh:
+            r = fresh.post(
+                "/api/v1/memory/import",
+                json={"content": json.dumps(_manifest()), "format": "json"},
+                headers={"X-API-Key": "test-api-key"},
+            )
+        assert r.status_code == 401, f"expected 401, got {r.status_code}: {r.text}"
+
+    def test_empty_tenant_header_401(self, client: TestClient) -> None:
+        r = client.get(
+            "/api/v1/memory/export",
+            params={"format": "json"},
+            headers={"X-Tenant-Id": "   ", "X-API-Key": "test-api-key"},
+        )
+        assert r.status_code == 401
+
+    def test_root_alias_no_tenant_serves_ui_not_export(
+        self, client: TestClient, monkeypatch
+    ) -> None:
+        """GET / is a protected path: a tenant-less request (fresh client)
+        gets 401 from the API-key middleware; a request with a tenant
+        serves the UI file when deployed — never the (scoped) export
+        branch for unauthenticated callers."""
+        import os
+
+        # Tenant-less request is rejected outright (fail-closed, #166).
+        with TestClient(app) as fresh:
+            r = fresh.get("/", headers={"X-API-Key": "test-api-key"})
+        assert r.status_code == 401, f"expected 401, got {r.status_code}: {r.text}"
+        # With a tenant: if the UI is deployed, GET / serves the UI file,
+        # not the export branch (no leak surface for the unauthenticated
+        # UI-load path).
+        monkeypatch.setenv("UI_PATH", os.path.join(os.getcwd(), "ui", "index.html"))
+        # Only reachable when the UI file exists (CI checks out the repo).
+        if not os.path.exists(os.environ["UI_PATH"]):
+            pytest.skip("ui/index.html not present in this environment")
+        r = client.get("/", headers=API_KEY_ONLY)
+        assert r.status_code == 200, r.text
+        assert "export_id" not in r.text
+
+    def test_root_alias_export_is_tenant_scoped(self, client: TestClient, monkeypatch) -> None:
+        """With a tenant header and no UI deployed, GET / exports the
+        caller's scoped memory (the legacy alias must not leak another
+        tenant's data either)."""
+        # Point the UI path at a missing file so the alias takes the export
+        # branch; seed a tenant's store first.
+        monkeypatch.setenv("UI_PATH", "/nonexistent/ui/index.html")
+        _import(client, TENANT_A, _manifest())
+
+        r_b = client.get("/", headers={**BASE_HEADERS, **TENANT_B})
+        assert r_b.status_code == 200, r_b.text
+        body_b = r_b.json()
+        assert body_b["counts"] == {"episodic": 0, "semantic": 0, "procedural": 0}, (
+            "GET / alias leaked data for tenant B — not tenant-scoped"
+        )
+
+        r_a = client.get("/", headers={**BASE_HEADERS, **TENANT_A})
+        assert r_a.status_code == 200, r_a.text
+        body_a = r_a.json()
+        assert body_a["counts"]["episodic"] == 3
+
+
+# ─── Audit hook: import is recorded under the caller's tenant ─────────────────
+
+
+def test_import_audit_uses_request_tenant(client: TestClient) -> None:
+    """The critical-operation audit entry (#110) is recorded under the
+    caller's tenant from request.state, not the RIKS_TENANT_ID env fallback."""
+    _import(client, TENANT_A, _manifest())
+
+    r = client.get(
+        "/api/v1/audit",
+        params={"category": "memory.import"},
+        headers=TENANT_A,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["tenant"] == "t184-tenant-a"
+    matching = [e for e in body["entries"] if e["endpoint"] == "/api/v1/memory/import"]
+    assert matching, "memory.import audit entry missing for the caller's tenant"
+    assert all(e["tenant"] == "t184-tenant-a" for e in matching)


### PR DESCRIPTION
## Ne değişti

**Problemi:** `/api/v1/memory/export`, `/api/v1/memory/import` ve `GET /` export alias'ı tenant doğrulamasını middleware'de yapıyordu (`X-Tenant-Id`) ama store'lar module-level **singleton**'ları (`_episodic_memory` vb.) kullanıyordu. Tenant A import → tenant B export aynı kayıtları görüyordu (staging'de doğrulandı, #183).

**Fix (`src/riks_context_engine/api/server.py`):**
- `_export_memory`: artık `request + tenant_id` alıyor, üç store'ı `_tenant_memory_registry.get_episodic/get_semantic/get_procedural(tenant_id)`'den çekiyor (`/api/chat` pattern'i, #158)
- `export_memory_api` / `import_memory_api`: `Request` enjekte ediliyor, `request.state.tenant_id` (TenantAuthMiddleware) ile scoped store'lar `export_memory` / `import_to_memory`'ye geçiyor
- Import audit hook: artık `request.state.tenant_id` altında kaydediliyor (öncesi env-fallback `RIKS_TENANT_ID`, prod'da hep 'unauthenticated' yazıyordu)
- `GET /` alias: tenant'lı isteklerde caller'ın kendi tenant export'ü; tenant'sız istek hâlâ UI servisi yapıyor (fail-closed). Response doğrudan döndürülüyor (JSONResponse / FileResponse) — JSON+File mixed endpoint için pydantic union-return modeli kullanılmıyor

## Nasıl test edildi

- `uv run pytest tests/` → **700 passed, 23 skipped, 3 xfailed, 3 xpassed** (lokal, tümü geçiyor)
- `uv run ruff check .` → All checks passed
- `uv run ruff format --check` → yeni/değişen dosyalar formatlı (docs/ altında pre-existing drift var, commit edilmedi — #181'te belgelenmiş)
- `uv run mypy src/` → Success: no issues found in 40 source files

## AC mapping

| AC | Test (tests/test_api/test_memory_tenant_scoping_e2e.py — 13 yeni test) |
|----|------|
| AC2 izolasyon | `TestCrossTenantIsolation`: A import(3 episodic) → B export = 0; A export → B import → A değişmez; semantic + procedural tier izolasyonu (tier başına test) |
| AC3 roundtrip | `TestSameTenantRoundtrip`: A import → A export → aynı 3 kayıt (id, content, tags, timestamp) |
| Import idempotency | `TestImportIdempotency`: merge=true → 2. import imported=0; farklı tenant'a re-import o tenant'ın scope'unda kalıyor |
| Fail-closed (#166) | `TestFailClosed`: tenant header'sız (fresh client) export/import → 401; boş tenant → 401; `GET /` tenant'sızda export değil UI, tenant'lıda tenant-scope export |
| Audit | `test_import_audit_uses_request_tenant`: audit, request tenant'ı altında (env fallback değil) |

**#167 e2e testi (tests/test_api/test_memory_roundtrip_e2e.py):** artık singleton yerine tenant-scoped registry üzerinden test ediyor — her tenant kendi header'ı ve kendi scoped store'ıyla (registry'den fetch, izolasyon assert'li), roundtrip amacı korunarak 13 teste genişletildi.

## Notlar
- Staging'e dokunulmadı
- `docs/` pre-existing format drift'i commit edilmedi (#181)
- `#183` staging bulgusuna referans: PR description'daki izolasyon deliği