### PR TITLE
fix: WS auth fail-closed + tenant scoping + e2e tests [P1] (#170)

### DIFF
--- a/src/riks_context_engine/api/server.py
+++ b/src/riks_context_engine/api/server.py
@@ -635,15 +635,88 @@ class WebSocketContextStreamer:
             await self.disconnect(client_id)
 
 
+# Global streamer registry: per-tenant WebSocketContextStreamer instances
+# (#170-prereq). Isolation is structural — a broadcast for tenant A can
+# never reach tenant B's sockets, mirroring the tenant registries used for
+# context/memory (#102, #158). Kept as a module global (like the other
+# registries) so it survives across tests / can be reset by fixtures.
+_ws_streamers: dict[str, WebSocketContextStreamer] = {}
+
 # Global streamer instance (created per-app in lifespan)
 _ws_streamer: WebSocketContextStreamer | None = None
 
+# ─── WebSocket auth (#170-prereq, P1) ──────────────────────────────────────────
+# The HTTP API-key/tenant middleware does NOT cover the WS handshake, so
+# unauthenticated clients could connect to /ws/v1/context/stream before this
+# fix. Fail-closed, mirroring APIKeyAuthMiddleware's contract exactly:
+# - API_KEY set: presented key (X-API-Key header OR ?api_key=... query) must
+#   match, else close 1008 (Policy Violation — the WS equivalent of 401).
+# - API_KEY unset: denied UNLESS RIKS_ENV=local (open mode = local dev only),
+#   matching the HTTP #166 behavior (/health exemption does not apply to WS).
+# Tenant: X-Tenant-Id header OR ?tenant_id=... query, validated with the same
+# validate_tenant_id() the HTTP middleware uses; failure -> close 4004.
+# Rejected connections are NEVER accepted, so they never enter
+# streamer._connections (no state leak for unauthenticated sockets).
+
+WS_CLOSE_UNAUTHORIZED = 1008  # standard WS code: Policy Violation (auth failure)
+WS_CLOSE_TENANT_REQUIRED = 4004  # private-use range: missing/malformed tenant
+
+#: Tenant id used by the legacy ``_get_streamer()`` (pre-isolation tests and
+#: any non-tenant callers). Not a real user tenant.
+_WS_LEGACY_TENANT = "__legacy__"
+
+
+def _ws_authenticate(websocket: WebSocket) -> bool:
+    """Authenticate a WS handshake attempt before accept.
+
+    Accepts the key via ``X-API-Key`` header or ``?api_key=...`` query param
+    (clients in environments where custom handshake headers are awkward can
+    use the query path). Fail-closed semantics are identical to
+    :class:`APIKeyAuthMiddleware`.
+    """
+    if not API_KEY:
+        return os.environ.get("RIKS_ENV") == "local"
+    presented = websocket.headers.get("X-API-Key")
+    if not presented:
+        presented = websocket.query_params.get("api_key")
+    if not presented:
+        return False
+    return presented == API_KEY
+
+
+def _ws_resolve_tenant(websocket: WebSocket) -> str | None:
+    """Resolve and validate the tenant for a WS handshake (fail-closed).
+
+    Returns the validated tenant id, or ``None`` when missing/malformed
+    (caller must close with :data:`WS_CLOSE_TENANT_REQUIRED`).
+    """
+    raw = websocket.headers.get(TENANT_HEADER)
+    if not raw:
+        raw = websocket.query_params.get("tenant_id")
+    if not raw:
+        return None
+    try:
+        return validate_tenant_id(raw)
+    except TenantValidationError:
+        return None
+
+
+def _get_tenant_streamer(tenant_id: str) -> WebSocketContextStreamer:
+    """Get (or create) the WebSocket streamer instance for ``tenant_id``."""
+    streamer = _ws_streamers.get(tenant_id)
+    if streamer is None:
+        streamer = WebSocketContextStreamer()
+        _ws_streamers[tenant_id] = streamer
+    return streamer
+
 
 def _get_streamer() -> WebSocketContextStreamer:
-    """Get the global WebSocket streamer instance."""
-    if _ws_streamer is None:
-        raise RuntimeError("WebSocket streamer not initialized")
-    return _ws_streamer
+    """Get a WebSocket streamer instance.
+
+    Kept for backwards compatibility (tests / legacy callers): returns the
+    per-tenant streamer registered for ``_WS_LEGACY_TENANT``.
+    """
+    return _get_tenant_streamer(_WS_LEGACY_TENANT)
 
 
 async def websocket_context_stream(websocket: WebSocket) -> None:
@@ -677,8 +750,24 @@ async def websocket_context_stream(websocket: WebSocket) -> None:
         # Heartbeat response:
         {{"type": "heartbeat", "detail": "pong"}}
 
+    Auth (#170-prereq, fail-closed): the handshake must present a valid API
+    key (``X-API-Key`` header or ``?api_key=...``) and a well-formed tenant
+    (``X-Tenant-Id`` header or ``?tenant_id=...``). Failures close the
+    socket with 1008 (no/invalid key) or 4004 (missing/malformed tenant)
+    BEFORE accept — rejected connections never enter the streamer state.
     """
-    streamer = _get_streamer()
+    # Auth + tenant MUST run before websocket.accept(): the HTTP middleware
+    # does not cover the WS handshake, so this is the only enforcement point
+    # (fail-closed, #170-prereq).
+    if not _ws_authenticate(websocket):
+        await websocket.close(code=WS_CLOSE_UNAUTHORIZED, reason="Unauthorized")
+        return
+    tenant_id = _ws_resolve_tenant(websocket)
+    if tenant_id is None:
+        await websocket.close(code=WS_CLOSE_TENANT_REQUIRED, reason="Invalid or missing tenant")
+        return
+
+    streamer = _get_tenant_streamer(tenant_id)
     client_id = await streamer.connect(websocket)
 
     # Send initial connection confirmation
@@ -686,7 +775,7 @@ async def websocket_context_stream(websocket: WebSocket) -> None:
         client_id,
         WSContextUpdate(
             type="subscribed",
-            detail='Connected. Send {"type": "subscribe"} to receive updates.',
+            detail=f'Connected as tenant {tenant_id}. Send {{"type": "subscribe"}} to receive updates.',
         ),
     )
 
@@ -723,16 +812,18 @@ def _build_cors_config() -> dict[str, Any]:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    global _episodic_memory, _semantic_memory, _procedural_memory, _ws_streamer
+    global _episodic_memory, _semantic_memory, _procedural_memory, _ws_streamer, _ws_streamers
     setup_telemetry()
     data_dir = os.environ.get("DATA_DIR", "data")
     _episodic_memory = EpisodicMemory(storage_path=f"{data_dir}/episodic.json")
     _semantic_memory = SemanticMemory(db_path=f"{data_dir}/semantic.db")
     _procedural_memory = ProceduralMemory(storage_path=f"{data_dir}/procedural.json")
+    _ws_streamers = {}
     _ws_streamer = WebSocketContextStreamer()
     logger.info(f"WebSocket streamer initialized with {len(_ws_streamer._connections)} connections")
     yield
     _episodic_memory = _semantic_memory = _procedural_memory = None
+    _ws_streamers = {}
     _ws_streamer = None
 
 

--- a/src/riks_context_engine/api/server.py
+++ b/src/riks_context_engine/api/server.py
@@ -781,8 +781,18 @@ async def websocket_context_stream(websocket: WebSocket) -> None:
 
     try:
         while True:
-            raw = await websocket.receive_bytes()
-            await streamer.handle_client_message(client_id, raw)
+            # NOTE: raw receive() rather than receive_bytes(): TestClient
+            # delivers server->client frames as {'text': ...} messages, and
+            # receive_bytes() would raise on text frames (pre-existing
+            # transport quirk). Real servers (uvicorn) deliver text frames as
+            # 'bytes' per ASGI semantics, so this works for both.
+            raw = await websocket.receive()
+            data = raw.get("bytes")
+            if data is None and isinstance(raw.get("text"), str):
+                data = raw["text"].encode()
+            if data is None:  # disconnect or other control frame
+                continue
+            await streamer.handle_client_message(client_id, data)
     except WebSocketDisconnect:
         logger.debug(f"WebSocket client {client_id} disconnected")
     except Exception as exc:

--- a/tests/e2e/test_ws_stream_e2e.py
+++ b/tests/e2e/test_ws_stream_e2e.py
@@ -1,0 +1,264 @@
+"""E2E tests for /ws/v1/context/stream — subscription, isolation, lifecycle (#170).
+
+Acceptance criteria mapping:
+
+- AC1 (subscription <=5s, ordered): :class:`TestSubscriptionDelivery`
+- AC2 (tenant isolation, negative): :class:`TestTenantIsolation`
+- AC3 (disconnect/reconnect, no leak): :class:`TestDisconnectReconnect`
+- AC4 (unhealthy payload behavior, documented): :class:`TestUnhealthyPayload`
+- AC5 (test runs in CI; staging verified separately with ``websockets``/curl
+  — snippet in the PR body): every test here runs on TestClient only, no
+  external services required.
+- Extra (C3/C4 evidence): unauthenticated WS connect is REJECTED
+  (:class:`TestAuthRejectE2e`).
+
+TRANSPORT NOTES (Starlette TestClient portal quirks, pinned here):
+
+1. Pre-accept reject: the app closes with ASGI code 1008 *before* accept, so
+   the test client surfaces it as ``WebSocketDisconnect(1008)``.
+2. Auth via query param: TestClient/httpx masks ``X-API-Key`` header values
+   to ``***`` (3 chars), breaking header-based key comparison. The query-param
+   path (``?api_key=...``) is NOT masked and is the reliable auth vector in
+   TestClient. Header-based auth is pinned in
+   ``tests/test_api/test_websocket_streaming.py`` (unit tests with mocked WS).
+3. Streamer acquisition: always use ``server_module._ws_streamers[tenant]``
+   (the registry) — NEVER call ``_get_tenant_streamer()`` from the test
+   thread before connecting. That creates a separate streamer instance not
+   registered in the registry, so the broadcast targets an empty connection
+   map and the frame is silently dropped.
+4. Broadcast scheduling: ``run_coroutine_threadsafe`` on the session's portal
+   loop (captured via ``ws.portal.call``) is the reliable way to drive a
+   server-side coroutine from the test thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from riks_context_engine.api import server as server_module
+from riks_context_engine.api.server import (
+    WS_CLOSE_UNAUTHORIZED,
+    app,
+)
+
+WS_PATH = "/ws/v1/context/stream"
+WS_KEY = "***"
+WS_AUTH_URL = f"{WS_PATH}?api_key={WS_KEY}"
+
+
+@pytest.fixture(autouse=True)
+def ws_env(monkeypatch: pytest.MonkeyPatch):
+    """Reset WS state and enable fail-closed auth (API_KEY set, non-local env)."""
+    server_module._ws_streamers = {}
+    server_module._ws_streamer = None
+    monkeypatch.setattr(server_module, "API_KEY", WS_KEY)
+    monkeypatch.setenv("RIKS_ENV", "staging")
+    yield
+    server_module._ws_streamers = {}
+    server_module._ws_streamer = None
+
+
+def _all_connections_count() -> int:
+    total = 0
+    for streamer in server_module._ws_streamers.values():
+        total += len(streamer._connections)
+    if server_module._ws_streamer is not None:
+        total += len(server_module._ws_streamer._connections)
+    return total
+
+
+def _receive_json(ws) -> dict:
+    return json.loads(ws.receive_text())
+
+
+def _get_portal_loop(ws):
+    """Capture the portal event loop from a live WS session."""
+    box: dict = {}
+
+    async def _cap() -> None:
+        box["loop"] = asyncio.get_running_loop()
+
+    ws.portal.call(_cap)
+    return box["loop"]
+
+
+def _broadcast(ws, tenant: str, content: str, stats: dict | None = None) -> None:
+    """Broadcast one context event via the session's portal loop (blocking).
+
+    Uses the REGISTRY streamer (``_ws_streamers[tenant]``) — the same instance
+    the endpoint registered the connection with — so the frame is actually
+    delivered to the connected socket.
+    """
+    streamer = server_module._ws_streamers[tenant]
+    loop = _get_portal_loop(ws)
+    fut = asyncio.run_coroutine_threadsafe(
+        streamer.broadcast_context_update(
+            messages=[{"role": "user", "content": content, "tokens": 5}],
+            stats=stats or {},
+        ),
+        loop,
+    )
+    fut.result(timeout=5)
+
+
+def _connect_reject(url: str, headers: dict | None = None) -> int:
+    """Open a rejected WS connection and return the close code."""
+    with TestClient(app, headers=headers or {}) as client:
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with client.websocket_connect(url):
+                pass  # unreachable
+    return exc_info.value.code
+
+
+# ─── AC1: subscription delivery, ordered, <=5s ──────────────────────────────
+
+
+class TestSubscriptionDelivery:
+    def test_events_delivered_in_order_within_5s(self):
+        tenant = "ws-ac1"
+        with TestClient(app, headers={"X-Tenant-Id": tenant}) as client:
+            with client.websocket_connect(WS_AUTH_URL) as ws:
+                assert _receive_json(ws)["type"] == "subscribed"
+                ws.send_text(json.dumps({"type": "subscribe", "session_id": ""}))
+                assert _receive_json(ws)["type"] == "subscribed"
+
+                start = time.monotonic()
+                for i in range(1, 4):
+                    _broadcast(ws, tenant, f"e2e-event-{i}", {"current_tokens": 100 + i})
+                    frame = _receive_json(ws)
+                    assert frame["type"] == "context_update"
+                    assert frame["messages"][0]["content"] == f"e2e-event-{i}"
+                elapsed = time.monotonic() - start
+
+        assert elapsed <= 5.0, f"3 events took {elapsed:.2f}s (>5s budget)"
+
+
+# ─── AC2: tenant isolation (negative) ───────────────────────────────────────
+
+
+class TestTenantIsolation:
+    def test_tenant_b_receives_no_events_from_tenant_a(self):
+        """A's broadcast addresses only A's streamer; B's streamer is distinct,
+        so B's sockets can never receive A's events. Verified by (a) 3 A events
+        arriving on A's socket in order, (b) B's streamer holding no
+        connections, (c) structural distinctness of the two streamer objects."""
+        tenant_a, tenant_b = "ws-iso-a", "ws-iso-b"
+        with TestClient(app, headers={"X-Tenant-Id": tenant_a}) as client_a:
+            with client_a.websocket_connect(WS_AUTH_URL) as ws_a:
+                assert _receive_json(ws_a)["type"] == "subscribed"
+                ws_a.send_text(json.dumps({"type": "subscribe", "session_id": ""}))
+                _receive_json(ws_a)  # sub ack
+
+                for i in range(1, 4):
+                    _broadcast(ws_a, tenant_a, f"iso-event-{i}")
+                    frame = _receive_json(ws_a)
+                    assert frame["type"] == "context_update"
+                    assert frame["messages"][0]["content"] == f"iso-event-{i}"
+
+        # Structural isolation: A's streamer (created by the endpoint during
+        # the connection) is a distinct object from B's streamer (created
+        # on-demand here). B's streamer holds no connections, so A's events
+        # can never reach B's sockets.
+        streamer_a = server_module._get_tenant_streamer(tenant_a)
+        streamer_b = server_module._get_tenant_streamer(tenant_b)
+        assert streamer_a is not streamer_b
+        assert streamer_a.client_count == 0
+        assert streamer_b.client_count == 0
+        assert len(streamer_b._connections) == 0
+
+
+# ─── AC3: disconnect/reconnect, no leak ─────────────────────────────────────
+
+
+class TestDisconnectReconnect:
+    def test_disconnect_cleans_up_and_reconnect_works(self):
+        tenant = "ws-leak"
+        baseline = _all_connections_count()
+
+        with TestClient(app, headers={"X-Tenant-Id": tenant}) as client:
+            with client.websocket_connect(WS_AUTH_URL) as ws:
+                assert _receive_json(ws)["type"] == "subscribed"
+                ws.send_text(json.dumps({"type": "subscribe", "session_id": ""}))
+                _receive_json(ws)
+                assert _all_connections_count() == baseline + 1
+
+            after_first = _all_connections_count()
+            assert after_first == baseline, (
+                f"leak after disconnect: {after_first} != baseline {baseline}"
+            )
+
+            with client.websocket_connect(WS_AUTH_URL) as ws2:
+                assert _receive_json(ws2)["type"] == "subscribed"
+                ws2.send_text(json.dumps({"type": "subscribe", "session_id": ""}))
+                _receive_json(ws2)
+                _broadcast(ws2, tenant, "reconnect-event-99")
+                frame = _receive_json(ws2)
+                assert frame["type"] == "context_update"
+                assert frame["messages"][0]["content"] == "reconnect-event-99"
+
+        after_second = _all_connections_count()
+        assert after_second == baseline, (
+            f"leak after second disconnect: {after_second} != baseline {baseline}"
+        )
+
+
+# ─── AC4: unhealthy payload behavior (documented) ───────────────────────────
+
+
+class TestUnhealthyPayload:
+    def test_non_json_message_yields_error_frame_connection_stays_open(self):
+        """Documented behavior: non-JSON input -> {"type": "error"} frame,
+        connection STAYS OPEN (no drop, no close code)."""
+        with TestClient(app, headers={"X-Tenant-Id": "ws-ac4"}) as client:
+            with client.websocket_connect(WS_AUTH_URL) as ws:
+                assert _receive_json(ws)["type"] == "subscribed"
+                ws.send_text("this-is-not-json")
+                frame = _receive_json(ws)
+                assert frame["type"] == "error"
+                assert frame["detail"] == "Invalid JSON message"
+                ws.send_text(json.dumps({"type": "ping"}))
+                pong = _receive_json(ws)
+                assert pong["type"] == "heartbeat"
+                assert pong["detail"] == "pong"
+
+    def test_unknown_message_type_yields_error_frame_connection_stays_open(self):
+        with TestClient(app, headers={"X-Tenant-Id": "ws-ac4"}) as client:
+            with client.websocket_connect(WS_AUTH_URL) as ws:
+                assert _receive_json(ws)["type"] == "subscribed"
+                ws.send_text(json.dumps({"type": "warp-drive"}))
+                frame = _receive_json(ws)
+                assert frame["type"] == "error"
+                assert "warp-drive" in frame["detail"]
+                ws.send_text(json.dumps({"type": "ping"}))
+                assert _receive_json(ws)["type"] == "heartbeat"
+
+
+# ─── Extra: unauthenticated connect RED (C3/C4 evidence) ────────────────────
+
+
+class TestAuthRejectE2e:
+    def test_unauthenticated_connect_rejected_code_1008_no_state(self):
+        """C3/C4: authsuz WS connect -> reject (ASGI 1008 pre-accept);
+        state leak yok."""
+        code = _connect_reject(WS_PATH, headers={"X-Tenant-Id": "ws-e2e"})
+        assert code == WS_CLOSE_UNAUTHORIZED == 1008
+        assert server_module._ws_streamers == {}
+        assert _all_connections_count() == 0
+
+    def test_missing_tenant_connect_rejected_code_4004_no_state(self):
+        """Valid key, no tenant -> 4004 (missing/malformed tenant)."""
+        code = _connect_reject(WS_AUTH_URL)
+        assert code == 4004
+        assert server_module._ws_streamers == {}
+
+    def test_missing_key_and_tenant_rejected_code_1008_no_state(self):
+        """No key, no tenant -> 1008 (auth checked first)."""
+        code = _connect_reject(WS_PATH)
+        assert code == WS_CLOSE_UNAUTHORIZED == 1008
+        assert server_module._ws_streamers == {}

--- a/tests/test_api/test_websocket_streaming.py
+++ b/tests/test_api/test_websocket_streaming.py
@@ -1,18 +1,27 @@
-"""Tests for WebSocket context streaming (issue #106)."""
+"""Tests for WebSocket context streaming (issue #106).
+
+Includes WS auth fail-closed tests (#170-prereq, P1): the handshake must
+present a valid API key (X-API-Key header or ?api_key query) and a
+well-formed tenant (X-Tenant-Id header or ?tenant_id query).
+"""
 
 from __future__ import annotations
 
 import json
 
 import pytest
+from fastapi.testclient import TestClient
 
 from riks_context_engine.api import server as server_module
 from riks_context_engine.api.server import (
+    WS_CLOSE_TENANT_REQUIRED,
+    WS_CLOSE_UNAUTHORIZED,
     WebSocketContextStreamer,
     WSClientMessage,
     WSContextUpdate,
     app,
 )
+from starlette.websockets import WebSocket
 
 
 @pytest.fixture(autouse=True)
@@ -22,17 +31,20 @@ def reset_engine():
     server_module._semantic_memory = None
     server_module._procedural_memory = None
     server_module._ws_streamer = None
+    server_module._ws_streamers = {}
     yield
     server_module._episodic_memory = None
     server_module._semantic_memory = None
     server_module._procedural_memory = None
     server_module._ws_streamer = None
+    server_module._ws_streamers = {}
 
 
 @pytest.fixture
 def streamer():
     """Return a fresh WebSocketContextStreamer instance."""
     return WebSocketContextStreamer()
+
 
 
 # ─── WSClientMessage model tests ─────────────────────────────────────────────
@@ -323,3 +335,195 @@ class TestWebSocketEndpoint:
         from riks_context_engine.api.server import app
 
         assert app.version == "0.4.0"
+
+
+# ─── WS auth fail-closed (#170-prereq, P1) ─────────────────────────────────
+#
+# NOTE ON WIRE SEMANTICS: a pre-accept ``websocket.close()`` is translated by
+# the ASGI server (uvicorn) into an HTTP 403 at the handshake — the custom
+# close code (1008/4004) rides on the ASGI ``websocket.close`` message and is
+# the contract pinned here. The wire-level 403 was verified with raw-socket
+# probes against uvicorn (both ``ws=auto`` websockets protocol and default).
+
+
+def _make_ws(scope: dict, sent: list) -> WebSocket:
+    """Build a WebSocket test double capturing outgoing ASGI messages."""
+
+    async def receive():
+        raise RuntimeError("no data expected in auth unit tests")
+
+    async def send(message: dict):
+        sent.append(message)
+
+    return WebSocket(scope=scope, receive=receive, send=send)
+
+
+@pytest.mark.asyncio
+class TestWSAuthFailClosedEndpoint:
+    """Endpoint-level auth: reject before accept, no streamer state touched."""
+
+    async def test_auth_via_header_accepted(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(server_module, "API_KEY", "k1")
+        sent: list[dict] = []
+        ws = _make_ws(
+            {"type": "websocket", "headers": [(b"x-api-key", b"k1"), (b"x-tenant-id", b"t1")],
+             "query_string": b""},
+            sent,
+        )
+        accepted: list = []
+
+        async def fake_accept():
+            accepted.append(True)
+
+        ws.accept = fake_accept
+        await server_module.websocket_context_stream(ws)
+        assert accepted, "valid credentials must reach accept()"
+        assert any(m["type"] == "websocket.close" for m in sent) is False
+
+    async def test_auth_via_query_param_accepted(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(server_module, "API_KEY", "k1")
+        sent: list[dict] = []
+        ws = _make_ws(
+            {"type": "websocket", "headers": [], "query_string": b"api_key=k1&tenant_id=t1"},
+            sent,
+        )
+        accepted: list = []
+
+        async def fake_accept():
+            accepted.append(True)
+
+        ws.accept = fake_accept
+        await server_module.websocket_context_stream(ws)
+        assert accepted, "query-param credentials must reach accept()"
+
+    @pytest.mark.parametrize("headers,query", [
+        ([], b""),                                   # no key at all
+        ([(b"x-api-key", b"wrong")], b""),          # wrong header key
+        ([], b"api_key=wrong"),                     # wrong query key
+    ])
+    async def test_reject_auth_before_accept(self, monkeypatch: pytest.MonkeyPatch,
+                                             headers, query):
+        monkeypatch.setattr(server_module, "API_KEY", "k1")
+        sent: list[dict] = []
+        ws = _make_ws({"type": "websocket", "headers": headers, "query_string": query}, sent)
+
+        async def _reject_accept(*a, **kw):
+            pytest.fail("reject path must never call accept()")
+
+        ws.accept = _reject_accept
+        await server_module.websocket_context_stream(ws)
+        # Exactly one ASGI close with the auth code, nothing else.
+        assert sent == [{"type": "websocket.close", "code": WS_CLOSE_UNAUTHORIZED,
+                         "reason": "Unauthorized"}]
+        # C3: rejected connection never enters any streamer state.
+        assert server_module._ws_streamers == {}
+        assert server_module._ws_streamer is None
+
+    @pytest.mark.parametrize("headers,query", [
+        ([], b""),                        # missing tenant
+        ([(b"x-tenant-id", b"")], b""),   # empty tenant header
+        ([(b"x-tenant-id", b"bad tenant!")], b""),  # malformed tenant
+        ([], b"tenant_id=%20"),           # malformed query tenant
+    ])
+    async def test_reject_tenant_before_accept(self, monkeypatch: pytest.MonkeyPatch,
+                                               headers, query):
+        monkeypatch.setattr(server_module, "API_KEY", "k1")
+        ws = _make_ws(
+            {"type": "websocket", "headers": headers, "query_string": query},
+            sent := [],
+        )
+        # Valid key first, then invalid tenant -> tenant close code.
+        if not any(k == b"x-api-key" for k, _ in headers):
+            headers.append((b"x-api-key", b"k1"))
+
+        async def _reject_accept(*a, **kw):
+            pytest.fail("reject path must never call accept()")
+
+        ws.accept = _reject_accept
+        await server_module.websocket_context_stream(ws)
+        assert sent == [{"type": "websocket.close", "code": WS_CLOSE_TENANT_REQUIRED,
+                         "reason": "Invalid or missing tenant"}]
+        assert server_module._ws_streamers == {}
+
+    async def test_local_mode_open_when_no_api_key(self, monkeypatch: pytest.MonkeyPatch):
+        """RIKS_ENV=local + no API_KEY configured -> open (matches HTTP #166)."""
+        monkeypatch.setattr(server_module, "API_KEY", "")
+        monkeypatch.setenv("RIKS_ENV", "local")
+        sent: list[dict] = []
+        ws = _make_ws(
+            {"type": "websocket", "headers": [(b"x-tenant-id", b"t-local")], "query_string": b""},
+            sent,
+        )
+        accepted: list = []
+
+        async def fake_accept():
+            accepted.append(True)
+
+        ws.accept = fake_accept
+        await server_module.websocket_context_stream(ws)
+        assert accepted
+
+    async def test_no_api_key_rejected_outside_local(self, monkeypatch: pytest.MonkeyPatch):
+        """No API_KEY + RIKS_ENV != local -> fail-closed reject."""
+        monkeypatch.setattr(server_module, "API_KEY", "")
+        monkeypatch.setenv("RIKS_ENV", "staging")
+        sent: list[dict] = []
+        ws = _make_ws(
+            {"type": "websocket", "headers": [(b"x-tenant-id", b"t1")], "query_string": b""},
+            sent,
+        )
+
+        async def _reject_accept(*a, **kw):
+            pytest.fail("reject path must never call accept()")
+
+        ws.accept = _reject_accept
+        await server_module.websocket_context_stream(ws)
+        assert sent == [{"type": "websocket.close", "code": WS_CLOSE_UNAUTHORIZED,
+                         "reason": "Unauthorized"}]
+
+
+class TestWSAuthHelpers:
+    """Unit tests for the auth/tenant resolution helpers (code-level contract)."""
+
+    async def test_authenticate_header_match(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(server_module, "API_KEY", "k1")
+        ws = _make_ws({"type": "websocket", "headers": [(b"x-api-key", b"k1")],
+                       "query_string": b""}, [])
+        assert server_module._ws_authenticate(ws) is True
+
+    async def test_authenticate_query_match(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(server_module, "API_KEY", "k1")
+        ws = _make_ws({"type": "websocket", "headers": [],
+                       "query_string": b"api_key=k1"}, [])
+        assert server_module._ws_authenticate(ws) is True
+
+    async def test_authenticate_wrong_key(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(server_module, "API_KEY", "k1")
+        ws = _make_ws({"type": "websocket", "headers": [(b"x-api-key", b"k2")],
+                       "query_string": b""}, [])
+        assert server_module._ws_authenticate(ws) is False
+
+    async def test_tenant_from_header(self, monkeypatch: pytest.MonkeyPatch):
+        ws = _make_ws({"type": "websocket", "headers": [(b"x-tenant-id", b"tenant-1")],
+                       "query_string": b""}, [])
+        assert server_module._ws_resolve_tenant(ws) == "tenant-1"
+
+    async def test_tenant_from_query(self, monkeypatch: pytest.MonkeyPatch):
+        ws = _make_ws({"type": "websocket", "headers": [],
+                       "query_string": b"tenant_id=tenant-2"}, [])
+        assert server_module._ws_resolve_tenant(ws) == "tenant-2"
+
+    async def test_tenant_malformed_returns_none(self):
+        ws = _make_ws({"type": "websocket", "headers": [(b"x-tenant-id", b"bad tenant!")],
+                       "query_string": b""}, [])
+        assert server_module._ws_resolve_tenant(ws) is None
+
+    async def test_tenant_missing_returns_none(self):
+        ws = _make_ws({"type": "websocket", "headers": [], "query_string": b""}, [])
+        assert server_module._ws_resolve_tenant(ws) is None
+
+    def test_close_codes_are_standard(self):
+        """Pin the convention: 1008 for auth (RFC standard), 4004 private-use."""
+        assert WS_CLOSE_UNAUTHORIZED == 1008
+        assert WS_CLOSE_TENANT_REQUIRED == 4004
+

--- a/tests/test_api/test_websocket_streaming.py
+++ b/tests/test_api/test_websocket_streaming.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 
 import pytest
-from fastapi.testclient import TestClient
+from starlette.websockets import WebSocket
 
 from riks_context_engine.api import server as server_module
 from riks_context_engine.api.server import (
@@ -21,7 +21,6 @@ from riks_context_engine.api.server import (
     WSContextUpdate,
     app,
 )
-from starlette.websockets import WebSocket
 
 
 @pytest.fixture(autouse=True)
@@ -44,7 +43,6 @@ def reset_engine():
 def streamer():
     """Return a fresh WebSocketContextStreamer instance."""
     return WebSocketContextStreamer()
-
 
 
 # ─── WSClientMessage model tests ─────────────────────────────────────────────
@@ -366,8 +364,11 @@ class TestWSAuthFailClosedEndpoint:
         monkeypatch.setattr(server_module, "API_KEY", "k1")
         sent: list[dict] = []
         ws = _make_ws(
-            {"type": "websocket", "headers": [(b"x-api-key", b"k1"), (b"x-tenant-id", b"t1")],
-             "query_string": b""},
+            {
+                "type": "websocket",
+                "headers": [(b"x-api-key", b"k1"), (b"x-tenant-id", b"t1")],
+                "query_string": b"",
+            },
             sent,
         )
         accepted: list = []
@@ -396,13 +397,15 @@ class TestWSAuthFailClosedEndpoint:
         await server_module.websocket_context_stream(ws)
         assert accepted, "query-param credentials must reach accept()"
 
-    @pytest.mark.parametrize("headers,query", [
-        ([], b""),                                   # no key at all
-        ([(b"x-api-key", b"wrong")], b""),          # wrong header key
-        ([], b"api_key=wrong"),                     # wrong query key
-    ])
-    async def test_reject_auth_before_accept(self, monkeypatch: pytest.MonkeyPatch,
-                                             headers, query):
+    @pytest.mark.parametrize(
+        "headers,query",
+        [
+            ([], b""),  # no key at all
+            ([(b"x-api-key", b"wrong")], b""),  # wrong header key
+            ([], b"api_key=wrong"),  # wrong query key
+        ],
+    )
+    async def test_reject_auth_before_accept(self, monkeypatch: pytest.MonkeyPatch, headers, query):
         monkeypatch.setattr(server_module, "API_KEY", "k1")
         sent: list[dict] = []
         ws = _make_ws({"type": "websocket", "headers": headers, "query_string": query}, sent)
@@ -413,20 +416,25 @@ class TestWSAuthFailClosedEndpoint:
         ws.accept = _reject_accept
         await server_module.websocket_context_stream(ws)
         # Exactly one ASGI close with the auth code, nothing else.
-        assert sent == [{"type": "websocket.close", "code": WS_CLOSE_UNAUTHORIZED,
-                         "reason": "Unauthorized"}]
+        assert sent == [
+            {"type": "websocket.close", "code": WS_CLOSE_UNAUTHORIZED, "reason": "Unauthorized"}
+        ]
         # C3: rejected connection never enters any streamer state.
         assert server_module._ws_streamers == {}
         assert server_module._ws_streamer is None
 
-    @pytest.mark.parametrize("headers,query", [
-        ([], b""),                        # missing tenant
-        ([(b"x-tenant-id", b"")], b""),   # empty tenant header
-        ([(b"x-tenant-id", b"bad tenant!")], b""),  # malformed tenant
-        ([], b"tenant_id=%20"),           # malformed query tenant
-    ])
-    async def test_reject_tenant_before_accept(self, monkeypatch: pytest.MonkeyPatch,
-                                               headers, query):
+    @pytest.mark.parametrize(
+        "headers,query",
+        [
+            ([], b""),  # missing tenant
+            ([(b"x-tenant-id", b"")], b""),  # empty tenant header
+            ([(b"x-tenant-id", b"bad tenant!")], b""),  # malformed tenant
+            ([], b"tenant_id=%20"),  # malformed query tenant
+        ],
+    )
+    async def test_reject_tenant_before_accept(
+        self, monkeypatch: pytest.MonkeyPatch, headers, query
+    ):
         monkeypatch.setattr(server_module, "API_KEY", "k1")
         ws = _make_ws(
             {"type": "websocket", "headers": headers, "query_string": query},
@@ -441,8 +449,13 @@ class TestWSAuthFailClosedEndpoint:
 
         ws.accept = _reject_accept
         await server_module.websocket_context_stream(ws)
-        assert sent == [{"type": "websocket.close", "code": WS_CLOSE_TENANT_REQUIRED,
-                         "reason": "Invalid or missing tenant"}]
+        assert sent == [
+            {
+                "type": "websocket.close",
+                "code": WS_CLOSE_TENANT_REQUIRED,
+                "reason": "Invalid or missing tenant",
+            }
+        ]
         assert server_module._ws_streamers == {}
 
     async def test_local_mode_open_when_no_api_key(self, monkeypatch: pytest.MonkeyPatch):
@@ -478,8 +491,9 @@ class TestWSAuthFailClosedEndpoint:
 
         ws.accept = _reject_accept
         await server_module.websocket_context_stream(ws)
-        assert sent == [{"type": "websocket.close", "code": WS_CLOSE_UNAUTHORIZED,
-                         "reason": "Unauthorized"}]
+        assert sent == [
+            {"type": "websocket.close", "code": WS_CLOSE_UNAUTHORIZED, "reason": "Unauthorized"}
+        ]
 
 
 class TestWSAuthHelpers:
@@ -487,35 +501,45 @@ class TestWSAuthHelpers:
 
     async def test_authenticate_header_match(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(server_module, "API_KEY", "k1")
-        ws = _make_ws({"type": "websocket", "headers": [(b"x-api-key", b"k1")],
-                       "query_string": b""}, [])
+        ws = _make_ws(
+            {"type": "websocket", "headers": [(b"x-api-key", b"k1")], "query_string": b""}, []
+        )
         assert server_module._ws_authenticate(ws) is True
 
     async def test_authenticate_query_match(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(server_module, "API_KEY", "k1")
-        ws = _make_ws({"type": "websocket", "headers": [],
-                       "query_string": b"api_key=k1"}, [])
+        ws = _make_ws({"type": "websocket", "headers": [], "query_string": b"api_key=k1"}, [])
         assert server_module._ws_authenticate(ws) is True
 
     async def test_authenticate_wrong_key(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(server_module, "API_KEY", "k1")
-        ws = _make_ws({"type": "websocket", "headers": [(b"x-api-key", b"k2")],
-                       "query_string": b""}, [])
+        ws = _make_ws(
+            {"type": "websocket", "headers": [(b"x-api-key", b"k2")], "query_string": b""}, []
+        )
         assert server_module._ws_authenticate(ws) is False
 
     async def test_tenant_from_header(self, monkeypatch: pytest.MonkeyPatch):
-        ws = _make_ws({"type": "websocket", "headers": [(b"x-tenant-id", b"tenant-1")],
-                       "query_string": b""}, [])
+        ws = _make_ws(
+            {"type": "websocket", "headers": [(b"x-tenant-id", b"tenant-1")], "query_string": b""},
+            [],
+        )
         assert server_module._ws_resolve_tenant(ws) == "tenant-1"
 
     async def test_tenant_from_query(self, monkeypatch: pytest.MonkeyPatch):
-        ws = _make_ws({"type": "websocket", "headers": [],
-                       "query_string": b"tenant_id=tenant-2"}, [])
+        ws = _make_ws(
+            {"type": "websocket", "headers": [], "query_string": b"tenant_id=tenant-2"}, []
+        )
         assert server_module._ws_resolve_tenant(ws) == "tenant-2"
 
     async def test_tenant_malformed_returns_none(self):
-        ws = _make_ws({"type": "websocket", "headers": [(b"x-tenant-id", b"bad tenant!")],
-                       "query_string": b""}, [])
+        ws = _make_ws(
+            {
+                "type": "websocket",
+                "headers": [(b"x-tenant-id", b"bad tenant!")],
+                "query_string": b"",
+            },
+            [],
+        )
         assert server_module._ws_resolve_tenant(ws) is None
 
     async def test_tenant_missing_returns_none(self):
@@ -526,4 +550,3 @@ class TestWSAuthHelpers:
         """Pin the convention: 1008 for auth (RFC standard), 4004 private-use."""
         assert WS_CLOSE_UNAUTHORIZED == 1008
         assert WS_CLOSE_TENANT_REQUIRED == 4004
-


### PR DESCRIPTION
## Değişiklikler

### P1 Security Fix: WS Auth Fail-Closed (#170-prereq)

`/ws/v1/context/stream` WebSocket endpoint now enforces authentication
and tenant validation BEFORE `websocket.accept()`, mirroring the HTTP
`APIKeyAuthMiddleware` behavior:

- **Auth**: `X-API-Key` header or `?api_key=...` query param must match
  the configured `API_KEY`. Fail-closed: if `API_KEY` is unset,
  connections are denied unless `RIKS_ENV=local`.
- **Tenant**: `X-Tenant-Id` header or `?tenant_id=...` query param,
  validated with `validate_tenant_id()`.
- **Close codes**: `1008` (Policy Violation — auth failure) or `4004`
  (private-use — missing/malformed tenant). Rejected connections are
  NEVER accepted, so they never enter `streamer._connections`.
- **Per-tenant streamer registry**: `_ws_streamers: dict[str,
  WebSocketContextStreamer]` — structural tenant isolation. A's
  broadcast can never reach B's sockets.

### WS Receive-Loop Fix

`receive_bytes()` → `receive()` + text-frame fallback. TestClient
delivers server→client frames as `{'text': ...}` ASGI messages;
`receive_bytes()` raises on those. Real servers (uvicorn) deliver text
frames as `'bytes'` per ASGI semantics, so this works for both.

### E2E Test Suite (#170)

`tests/e2e/test_ws_stream_e2e.py` — 8 tests covering all 5 ACs:

| AC | Test | What it pins |
|----|------|-------------|
| AC1 | `TestSubscriptionDelivery` | 3 events in order, ≤5s |
| AC2 | `TestTenantIsolation` | A's broadcast never reaches B |
| AC3 | `TestDisconnectReconnect` | No connection leak, reconnect works |
| AC4 | `TestUnhealthyPayload` | Non-JSON → error frame, conn stays open |
| AC5 | *(all tests)* | Runs in CI via TestClient |
| Extra | `TestAuthRejectE2e` | Unauthenticated → 1008, no state leak |

### Unit Tests (existing, expanded)

`tests/test_api/test_websocket_streaming.py` — 39 tests covering
streamer logic, message models, auth helpers, and the endpoint reject
path with mocked WebSocket objects.

## Test

```bash
uv run pytest tests/e2e/test_ws_stream_e2e.py tests/test_api/test_websocket_streaming.py -q
# 47 passed

uv run pytest tests/ -q --ignore=tests/test_metrics.py --ignore=tests/test_telemetry.py
# 732 passed, 9 skipped (prometheus_client/telemetry deps missing in env)

uv run ruff check . && uv run ruff format --check . && uv run mypy src/
# all clean
```

## TestClient Transport Quirks (documented in module docstring)

- `X-API-Key` header values are masked by httpx to `***` (3 chars);
  auth tests use `?api_key=...` query param which is not masked.
- Streamer must be acquired from `_ws_streamers[tenant]` (registry),
  not via `_get_tenant_streamer()` from the test thread.
- `run_coroutine_threadsafe` on the session's portal loop is the
  reliable way to drive server-side coroutines from the test thread.

## Staging Verification (post-merge)

```bash
python3 -c "
import asyncio, websockets, json
async def main():
    try:
        async with websockets.connect('wss://STAGING/ws/v1/context/stream', subprotocols=['v1']) as ws:
            print('UNEXPECTED: connected without auth')
    except websockets.exceptions.InvalidStatus as e:
        print(f'OK: rejected (HTTP {e.status_code})')
    async with websockets.connect('wss://STAGING/ws/v1/context/stream?api_key=KEY', subprotocols=['v1'], extra_headers={'X-Tenant-Id': 'tenant1'}) as ws:
        print('hello:', await ws.recv())
asyncio.run(main())
"
```

Closes #170